### PR TITLE
Update configuration resolving mechanism

### DIFF
--- a/application/Common/Shared/Configuration/IConfiguration.cs
+++ b/application/Common/Shared/Configuration/IConfiguration.cs
@@ -9,8 +9,6 @@ namespace MORR.Shared.Configuration
     [InheritedExport]
     public interface IConfiguration
     {
-        string GetIdentifier() => GetType().ToString();
-
         /// <summary>
         ///     Parses the configuration from the provided value
         /// </summary>

--- a/application/Core/MORR/Data/Capture/Video/WinAPI/DesktopCaptureConfiguration.cs
+++ b/application/Core/MORR/Data/Capture/Video/WinAPI/DesktopCaptureConfiguration.cs
@@ -20,8 +20,6 @@ namespace MORR.Core.Data.Capture.Video.WinAPI
         /// </summary>
         public bool PromptUserForMonitorSelection { get; private set; }
 
-        public string Identifier { get; } = "DesktopCapture";
-
         public void Parse(RawConfiguration configuration)
         {
             var element = JsonDocument.Parse(configuration.RawValue).RootElement;

--- a/application/Core/MORR/Modules/GlobalModuleConfiguration.cs
+++ b/application/Core/MORR/Modules/GlobalModuleConfiguration.cs
@@ -9,7 +9,7 @@ using MORR.Shared.Modules;
 
 namespace MORR.Core.Modules
 {
-    [Export(typeof(GlobalModuleConfiguration)), PartCreationPolicy(CreationPolicy.Shared)]
+    [Export(typeof(GlobalModuleConfiguration))]
     public class GlobalModuleConfiguration : IConfiguration
     {
         /// <summary>

--- a/application/Core/MORR/Recording/RecordingConfiguration.cs
+++ b/application/Core/MORR/Recording/RecordingConfiguration.cs
@@ -8,7 +8,6 @@ using MORR.Shared.Configuration;
 namespace MORR.Core.Recording
 {
     [Export(typeof(RecordingConfiguration))]
-    [Export(typeof(IConfiguration))]
     public class RecordingConfiguration : IConfiguration
     {
         /// <summary>


### PR DESCRIPTION
This is a quick fix to enable the loading of `IConfiguration` instances specified in assemblies that are dynamically loaded. Instead of resolving the `IConfiguration` to use via a string, this tries to load the type to use from the configuration file and then picks the `IConfiguration` that is of the specified type.