### PR TITLE
Make backgroundscript persistent.

### DIFF
--- a/application/BrowserExtension/materials/manifest.json
+++ b/application/BrowserExtension/materials/manifest.json
@@ -5,7 +5,7 @@
   "permissions": ["<all_urls>", "activeTab", "storage", "tabs", "webNavigation", "downloads"],
   "background": {
     "scripts": ["background.js"],
-    "persistent": false
+    "persistent": true
   },
   "options_ui": {
     "page": "options.html"


### PR DESCRIPTION
This fixes chrome (and edge) deactivating the backgroundscript if the status stays disconnected for a certain time, which would result in the browser not checking for a connection to the MORR application anymore until restarted.