### PR TITLE
Fixed GlobalHook sometimes not properly attaching.

### DIFF
--- a/application/Common/HookLibrary/dllmain.cpp
+++ b/application/Common/HookLibrary/dllmain.cpp
@@ -149,11 +149,11 @@ DLL void SetHook(WH_MessageCallBack progressCallback) {
             UnhookWindowsHookEx(CallWndProcHook);
         GetMessageHook = nullptr;
         CallWndProcHook = nullptr;
+        if (dispatcherthread)
+            dispatcherthread->join();
         dispatcherthread = nullptr;
         globalBufferIterator = 0;
         ZeroMemory(globalMessageBuffer, sizeof(globalMessageBuffer));
-        if (dispatcherthread)
-            dispatcherthread->join();
     }
     running = true;
     globalBufferIterator = 0;

--- a/application/Common/Shared/Utility/GlobalHook.cs
+++ b/application/Common/Shared/Utility/GlobalHook.cs
@@ -114,10 +114,11 @@ namespace MORR.Shared.Utility
         }
 
         /// <summary>
-        ///     Free the loaded library.
+        ///     Free the loaded library. To be called when this application terminates.
         /// </summary>
         public static void FreeLibrary()
         {
+            Unhook();
             if (hookLibrary != IntPtr.Zero)
             {
                 //the library is loaded twice. Once for the DLLImports above, once by LoadLibrary.


### PR DESCRIPTION
This PR fixes the reliability issue when the hook is not properly detached on MORR termination. It should now _always_ work, no matter how the previous instance of MORR was terminated.

Closes #81 