### PR TITLE
Implement JsonEncoder and JsonDecoder

### DIFF
--- a/application/BuildEnvironment/config.morr
+++ b/application/BuildEnvironment/config.morr
@@ -7,7 +7,7 @@
     ]
   },
   "MORR.Core.Session.SessionConfiguration": {
-    "Encoder": "MORR.Core.CLI.Output.OutputFormatter",
+    "Encoder": "MORR.Core.Data.Transcoding.Json.JsonEncoder",
     "RecordingDirectory": "%userprofile%\\Videos\\MORR"
   },
   "MORR.Core.Data.Capture.Video.Desktop.DesktopCaptureConfiguration": {

--- a/application/BuildEnvironment/config.morr
+++ b/application/BuildEnvironment/config.morr
@@ -2,12 +2,14 @@
   "MORR.Core.Modules.GlobalModuleConfiguration": {
     "EnabledModules": [
       "MORR.Core.Data.IntermediateFormat.Json.JsonIntermediateFormatSerializer",
+      "MORR.Core.Data.IntermediateFormat.Json.JsonIntermediateFormatDeserializer",
       "MORR.Modules.Keyboard.KeyboardModule",
       "MORR.Modules.WebBrowser.WebBrowserModule"
     ]
   },
   "MORR.Core.Session.SessionConfiguration": {
     "Encoder": "MORR.Core.Data.Transcoding.Json.JsonEncoder",
+    "Decoder": "MORR.Core.Data.Transcoding.Json.JsonDecoder",
     "RecordingDirectory": "%userprofile%\\Videos\\MORR"
   },
   "MORR.Core.Data.Capture.Video.Desktop.DesktopCaptureConfiguration": {

--- a/application/Common/Shared/Events/Queue/Aliases.cs
+++ b/application/Common/Shared/Events/Queue/Aliases.cs
@@ -29,8 +29,8 @@ namespace MORR.Shared.Events.Queue
     /// <typeparam name="T">The type of <see cref="Event" /> in this queue.</typeparam>
     public abstract class DefaultDecodeableEventQueue<T> : DecodeableEventQueue<T> where T : Event
     {
-        protected DefaultDecodeableEventQueue(int bufferCapacity = 1024) : base(
-            new BoundedSingleConsumerChannelStrategy<T>(bufferCapacity)) { }
+        protected DefaultDecodeableEventQueue(int bufferCapacity = 1024, uint? maxConsumers = null) : base(
+            new BoundedMultiConsumerChannelStrategy<T>(bufferCapacity, maxConsumers)) { }
     }
 
     /// <summary>

--- a/application/Core/CLI/Output/OutputFormatter.cs
+++ b/application/Core/CLI/Output/OutputFormatter.cs
@@ -40,7 +40,7 @@ namespace MORR.Core.CLI.Output
                 throw new EncodingException();
             }
 
-            var output = Encoding.UTF8.GetString(sample.SerializedData);
+            var output = Encoding.UTF8.GetString(sample.Data);
             var timestamp = DateTime.Now.ToString(DateFormatString);
 
             Console.WriteLine($"{timestamp}: {output}");

--- a/application/Core/MORR/Data/IntermediateFormat/IntermediateFormatSample.cs
+++ b/application/Core/MORR/Data/IntermediateFormat/IntermediateFormatSample.cs
@@ -11,11 +11,11 @@ namespace MORR.Core.Data.IntermediateFormat
         /// <summary>
         ///     The type of the event that is serialized.
         /// </summary>
-        public Type EventType { get; set; }
+        public Type Type { get; set; }
 
         /// <summary>
         ///     The data that is serialized.
         /// </summary>
-        public byte[] SerializedData { get; set; }
+        public byte[] Data { get; set; }
     }
 }

--- a/application/Core/MORR/Data/IntermediateFormat/Json/JsonIntermediateFormatDeserializer.cs
+++ b/application/Core/MORR/Data/IntermediateFormat/Json/JsonIntermediateFormatDeserializer.cs
@@ -45,9 +45,9 @@ namespace MORR.Core.Data.IntermediateFormat.Json
         {
             await foreach (var sample in IntermediateFormatSampleQueue.GetEvents())
             {
-                if (sample.EventType == eventQueue.EventType)
+                if (sample.Type == eventQueue.EventType)
                 {
-                    var @event = JsonSerializer.Deserialize(sample.SerializedData, sample.EventType);
+                    var @event = JsonSerializer.Deserialize(sample.Data, sample.Type);
                     eventQueue.Enqueue(@event);
                 }
             }

--- a/application/Core/MORR/Data/IntermediateFormat/Json/JsonIntermediateFormatSample.cs
+++ b/application/Core/MORR/Data/IntermediateFormat/Json/JsonIntermediateFormatSample.cs
@@ -1,4 +1,20 @@
-﻿namespace MORR.Core.Data.IntermediateFormat.Json
+﻿using System.Text.Json;
+
+namespace MORR.Core.Data.IntermediateFormat.Json
 {
-    public class JsonIntermediateFormatSample : IntermediateFormatSample { }
+    /// <summary>
+    ///     A sample in JSON intermediate format.
+    /// </summary>
+    public class JsonIntermediateFormatSample : IntermediateFormatSample
+    {
+        /// <summary>
+        ///     The data that is serialized in JSON-compatible format.
+        /// </summary>
+        public JsonDocument JsonEncodedData => JsonDocument.Parse(Data);
+
+        /// <summary>
+        ///     The type of the event that is serialized in JSON-compatible format.
+        /// </summary>
+        public JsonEncodedText JsonEncodedType => JsonEncodedText.Encode(Type.ToString());
+    }
 }

--- a/application/Core/MORR/Data/IntermediateFormat/Json/JsonIntermediateFormatSerializer.cs
+++ b/application/Core/MORR/Data/IntermediateFormat/Json/JsonIntermediateFormatSerializer.cs
@@ -52,8 +52,8 @@ namespace MORR.Core.Data.IntermediateFormat.Json
 
             var sample = new JsonIntermediateFormatSample
             {
-                EventType = eventType,
-                SerializedData = serializedData,
+                Type = eventType,
+                Data = serializedData,
                 IssuingModule = Identifier
             };
 

--- a/application/Core/MORR/Data/Transcoding/Exceptions/DecodingException.cs
+++ b/application/Core/MORR/Data/Transcoding/Exceptions/DecodingException.cs
@@ -5,5 +5,12 @@ namespace MORR.Core.Data.Transcoding.Exceptions
     /// <summary>
     ///     A generic decoding exception
     /// </summary>
-    public class DecodingException : Exception { }
+    public class DecodingException : Exception
+    {
+        public DecodingException() { }
+
+        public DecodingException(string message) : base(message) { }
+
+        public DecodingException(string message, Exception innerException) : base(message, innerException) { }
+    }
 }

--- a/application/Core/MORR/Data/Transcoding/Json/JsonDecoder.cs
+++ b/application/Core/MORR/Data/Transcoding/Json/JsonDecoder.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MORR.Core.Data.IntermediateFormat.Json;
+using MORR.Core.Data.Transcoding.Exceptions;
+using MORR.Shared.Events.Queue;
+using MORR.Shared.Utility;
+
+namespace MORR.Core.Data.Transcoding.Json
+{
+    public class JsonDecoder : DefaultDecodeableEventQueue<JsonIntermediateFormatSample>, IDecoder
+    {
+        public static Guid Identifier { get; } = new Guid("E943EACB-5AD1-49A7-92CE-C42E7AD8995B");
+
+        public void Decode(FilePath path)
+        {
+            Task.Run(() => DecodeEvents(path));
+        }
+
+        private async void DecodeEvents(FilePath path)
+        {
+            await using var fileStream = File.OpenRead(path.ToString());
+            var document = JsonDocument.Parse(fileStream).RootElement;
+
+            foreach (var eventElement in document.EnumerateArray())
+            {
+                var encodedType = eventElement.GetProperty(nameof(JsonIntermediateFormatSample.Type)).GetString();
+                var type = Utility.GetTypeFromAnyAssembly(encodedType);
+
+                if (type == null)
+                {
+                    throw new DecodingException($"Failed to parse event type {encodedType}.");
+                }
+
+                var encodedData = eventElement.GetProperty(nameof(JsonIntermediateFormatSample.Data)).GetRawText();
+                var data = Encoding.UTF8.GetBytes(encodedData);
+
+                var intermediateFormatSample = new JsonIntermediateFormatSample
+                {
+                    Type = type,
+                    Data = data,
+                    IssuingModule = Identifier
+                };
+
+                Enqueue(intermediateFormatSample);
+            }
+        }
+    }
+}

--- a/application/Core/MORR/Data/Transcoding/Json/JsonEncoder.cs
+++ b/application/Core/MORR/Data/Transcoding/Json/JsonEncoder.cs
@@ -1,0 +1,47 @@
+﻿using System.ComponentModel.Composition;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MORR.Core.Data.IntermediateFormat.Json;
+using MORR.Shared.Events.Queue;
+using MORR.Shared.Utility;
+
+namespace MORR.Core.Data.Transcoding.Json
+{
+    public class JsonEncoder : IEncoder
+    {
+        [Import]
+        private IEncodeableEventQueue<JsonIntermediateFormatSample> IntermediateFormatSampleQueue { get; set; }
+
+        public void Encode(DirectoryPath directoryRecordingPath)
+        {
+            Task.Run(() => EncodeEvents(directoryRecordingPath));
+        }
+
+        private async void EncodeEvents(DirectoryPath recordingDirectoryPath)
+        {
+            await using var fileStream = GetFileStreamForOutput(recordingDirectoryPath);
+            var writer = new Utf8JsonWriter(fileStream);
+            writer.WriteStartArray();
+
+            await foreach (var sample in IntermediateFormatSampleQueue.GetEvents())
+            {
+                writer.WriteStartObject();
+                writer.WriteString(nameof(sample.Type), sample.JsonEncodedType);
+                // As there is no WriteRaw method on Utf8JsonWriter, we have to use a workaround to write the data
+                writer.WritePropertyName(nameof(sample.Data));
+                sample.JsonEncodedData.WriteTo(writer);
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
+        }
+
+        private static FileStream GetFileStreamForOutput(DirectoryPath directoryPath)
+        {
+            var filePath = Path.Combine(directoryPath.ToString(), "event_data.json"); // TODO Make this configurable?
+            var fileStream = File.OpenWrite(filePath);
+            return fileStream;
+        }
+    }
+}

--- a/application/Core/MORR/Data/Transcoding/Json/JsonEncoder.cs
+++ b/application/Core/MORR/Data/Transcoding/Json/JsonEncoder.cs
@@ -21,15 +21,15 @@ namespace MORR.Core.Data.Transcoding.Json
         private async void EncodeEvents(DirectoryPath recordingDirectoryPath)
         {
             await using var fileStream = GetFileStreamForOutput(recordingDirectoryPath);
-            var writer = new Utf8JsonWriter(fileStream);
+            await using var writer = new Utf8JsonWriter(fileStream);
             writer.WriteStartArray();
 
             await foreach (var sample in IntermediateFormatSampleQueue.GetEvents())
             {
                 writer.WriteStartObject();
-                writer.WriteString(nameof(sample.Type), sample.JsonEncodedType);
+                writer.WriteString(nameof(JsonIntermediateFormatSample.Type), sample.JsonEncodedType);
                 // As there is no WriteRaw method on Utf8JsonWriter, we have to use a workaround to write the data
-                writer.WritePropertyName(nameof(sample.Data));
+                writer.WritePropertyName(nameof(JsonIntermediateFormatSample.Data));
                 sample.JsonEncodedData.WriteTo(writer);
                 writer.WriteEndObject();
             }

--- a/application/Core/MORR/MORR.csproj
+++ b/application/Core/MORR/MORR.csproj
@@ -23,6 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Common\Shared\Shared.csproj"/>
+    <ProjectReference Include="..\..\Common\Shared\Shared.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Explanation

This PR implements JSON-encoding and decoding with `JsonEncoder` and `JsonDecoder`. It requires the intermediate format to be JSON (e.g. `JsonIntermediateFormatSerializer` and `JsonIntermediateFormatDeserializer` are required for encoding/decoding).

## Known issues

- Currently `IEncoder.Encoder` and `IDecoder.Decode` are non-blocking. Therefore the current implementation of `ISessionManager.Process` will finish before decoding can begin. This may be fixed through an additional property in the future or by making those methods block again - this is something that needs to be discussed.
- Currently there is no mechanism for the `JsonEncoder` to know when recording has finished, so the created file will not necessarily be written fully (or at all). This should not be a problem once we implement a mechansim to propagate event queues finishing the enqueue operation (I have already proposed such a mechanism, but it still has to be implemented).

Closes #13 