### PR TITLE
Fix DllNotFoundException for vcruntime140_cor3.dll

### DIFF
--- a/application/Modules/Mouse/Mouse.csproj
+++ b/application/Modules/Mouse/Mouse.csproj
@@ -36,7 +36,13 @@
       <HintPath>C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App\3.1.1\PresentationCore.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase">
-    <HintPath>C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App\3.1.1\WindowsBase.dll</HintPath>
+      <HintPath>C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App\3.1.1\WindowsBase.dll</HintPath>
     </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App\3.1.1\vcruntime140_cor3.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>  
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #93 

This works around the actual problem by just copying the dll to the output folder. Please check whether this fix also works for you.