### PR TITLE
Stop sessions correctly

### DIFF
--- a/application/BuildEnvironment/config.morr
+++ b/application/BuildEnvironment/config.morr
@@ -3,12 +3,18 @@
     "EnabledModules": [
       "MORR.Core.Data.IntermediateFormat.Json.JsonIntermediateFormatSerializer",
       "MORR.Core.Data.IntermediateFormat.Json.JsonIntermediateFormatDeserializer",
+      "MORR.Core.Data.Capture.Video.Desktop.DesktopCapture",
       "MORR.Modules.Keyboard.KeyboardModule"
     ]
   },
   "MORR.Core.Session.SessionConfiguration": {
-    "Encoder": "MORR.Core.Data.Transcoding.Json.JsonEncoder",
-    "Decoder": "MORR.Core.Data.Transcoding.Json.JsonDecoder",
+    "Encoders": [
+      "MORR.Core.Data.Transcoding.Json.JsonEncoder",
+      "MORR.Core.Data.Transcoding.Mpeg.MpegEncoder"
+    ],
+    "Decoders": [
+      "MORR.Core.Data.Transcoding.Json.JsonDecoder"
+    ],
     "RecordingDirectory": "%userprofile%\\Videos\\MORR"
   },
   "MORR.Core.Data.Transcoding.Json.JsonEncoderConfiguration": {
@@ -16,5 +22,16 @@
   },
   "MORR.Core.Data.Transcoding.Json.JsonDecoderConfiguration": {
     "RelativeFilePath": "event_data.json"
+  },
+  "MORR.Core.Data.Transcoding.Mpeg.MpegEncoderConfiguration": {
+    "Width": 1920,
+    "Height": 1080,
+    "KiloBitsPerSecond": 4000,
+    "FramesPerSecond": 60,
+    "RelativeFilePath": "desktop_capture.mp4"
+  },
+  "MORR.Core.Data.Capture.Video.Desktop.DesktopCaptureConfiguration": {
+    "PromptUserForMonitorSelection": false,
+    "MonitorIndex": 0
   }
 }

--- a/application/Common/Shared/Events/Queue/DecodeableEventQueue.cs
+++ b/application/Common/Shared/Events/Queue/DecodeableEventQueue.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Threading;
 using MORR.Shared.Events.Queue.Strategy;
 
 namespace MORR.Shared.Events.Queue
@@ -17,14 +16,19 @@ namespace MORR.Shared.Events.Queue
             this.storageStrategy = storageStrategy;
         }
 
-        public IAsyncEnumerable<T> GetEvents(CancellationToken cancellationToken = default)
+        public IAsyncEnumerable<T> GetEvents()
         {
-            return storageStrategy.GetEvents(cancellationToken);
+            return storageStrategy.GetEvents();
         }
 
         protected void Enqueue(T @event)
         {
             storageStrategy.Enqueue(@event);
+        }
+
+        protected void NotifyOnEnqueueFinished()
+        {
+            storageStrategy.NotifyOnEnqueueFinished();
         }
     }
 }

--- a/application/Common/Shared/Events/Queue/EncodeableEventQueue.cs
+++ b/application/Common/Shared/Events/Queue/EncodeableEventQueue.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Threading;
 using MORR.Shared.Events.Queue.Strategy;
 
 namespace MORR.Shared.Events.Queue
@@ -17,14 +16,19 @@ namespace MORR.Shared.Events.Queue
             this.storageStrategy = storageStrategy;
         }
 
-        public IAsyncEnumerable<T> GetEvents(CancellationToken cancellationToken = default)
+        public IAsyncEnumerable<T> GetEvents()
         {
-            return storageStrategy.GetEvents(cancellationToken);
+            return storageStrategy.GetEvents();
         }
 
         protected void Enqueue(T @event)
         {
             storageStrategy.Enqueue(@event);
+        }
+
+        protected void NotifyOnEnqueueFinished()
+        {
+            storageStrategy.NotifyOnEnqueueFinished();
         }
     }
 }

--- a/application/Common/Shared/Events/Queue/IDecodeableEventQueue.cs
+++ b/application/Common/Shared/Events/Queue/IDecodeableEventQueue.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Threading;
 
 namespace MORR.Shared.Events.Queue
 {
@@ -13,6 +12,6 @@ namespace MORR.Shared.Events.Queue
         ///     Asynchronously gets all events as concrete type <typeparamref name="T" />.
         /// </summary>
         /// <returns>A stream of <typeparamref name="T" /></returns>
-        IAsyncEnumerable<T> GetEvents(CancellationToken cancellationToken = default);
+        IAsyncEnumerable<T> GetEvents();
     }
 }

--- a/application/Common/Shared/Events/Queue/IEncodeableEventQueue.cs
+++ b/application/Common/Shared/Events/Queue/IEncodeableEventQueue.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Threading;
 
 namespace MORR.Shared.Events.Queue
 {
@@ -13,6 +12,6 @@ namespace MORR.Shared.Events.Queue
         ///     Asynchronously gets all events as concrete type <typeparamref name="T" />.
         /// </summary>
         /// <returns>A stream of <typeparamref name="T" /></returns>
-        IAsyncEnumerable<T> GetEvents(CancellationToken cancellationToken = default);
+        IAsyncEnumerable<T> GetEvents();
     }
 }

--- a/application/Common/Shared/Events/Queue/ISupportDeserializationEventQueue.cs
+++ b/application/Common/Shared/Events/Queue/ISupportDeserializationEventQueue.cs
@@ -3,7 +3,7 @@
 namespace MORR.Shared.Events.Queue
 {
     /// <summary>
-    ///     Provides a single-writer-multiple-reader queue for <see cref="Event"/> types with support for deserialization.
+    ///     Provides a single-writer-multiple-reader queue for <see cref="Event" /> types with support for deserialization.
     /// </summary>
     /// <typeparam name="T">The type of the event</typeparam>
     public interface ISupportDeserializationEventQueue<out T> where T : Event
@@ -18,5 +18,10 @@ namespace MORR.Shared.Events.Queue
         /// </summary>
         /// <param name="event">The event to enqueue</param>
         void Enqueue(object @event);
+
+        /// <summary>
+        ///     Notifies the event queue that no more events will be enqueued.
+        /// </summary>
+        void NotifyOnEnqueueFinished();
     }
 }

--- a/application/Common/Shared/Events/Queue/ReadOnlyEventQueue.cs
+++ b/application/Common/Shared/Events/Queue/ReadOnlyEventQueue.cs
@@ -25,5 +25,10 @@ namespace MORR.Shared.Events.Queue
         {
             storageStrategy.Enqueue(@event);
         }
+
+        protected void NotifyOnEnqueueFinished()
+        {
+            storageStrategy.NotifyOnEnqueueFinished();
+        }
     }
 }

--- a/application/Common/Shared/Events/Queue/Strategy/IEventQueueStorageStrategy.cs
+++ b/application/Common/Shared/Events/Queue/Strategy/IEventQueueStorageStrategy.cs
@@ -17,5 +17,10 @@ namespace MORR.Shared.Events.Queue.Strategy
         /// </summary>
         /// <param name="event">The event to enqueue</param>
         void Enqueue(T @event);
+
+        /// <summary>
+        /// Notifies the event queue that no more events will be enqueued.
+        /// </summary>
+        void NotifyOnEnqueueFinished();
     }
 }

--- a/application/Common/Shared/Events/Queue/Strategy/MultiConsumer/MultiConsumerChannelStrategy.cs
+++ b/application/Common/Shared/Events/Queue/Strategy/MultiConsumer/MultiConsumerChannelStrategy.cs
@@ -60,6 +60,19 @@ namespace MORR.Shared.Events.Queue.Strategy.MultiConsumer
             await EnqueueAsync(receivingChannel, @event);
         }
 
+        public void NotifyOnEnqueueFinished()
+        {
+            receivingChannel.Writer.Complete();
+
+            foreach (var channel in offeringChannels)
+            {
+                channel.Writer.Complete();
+            }
+
+            offeringChannels.Clear();
+            receivingChannel = CreateReceivingChannel();
+        }
+
         private ValueTask EnqueueAsync(Channel<TEvent> channel, TEvent @event)
         {
             async Task AsyncSlowPath(TEvent @event)

--- a/application/Common/Shared/Events/Queue/Strategy/SingleConsumer/SingleConsumerChannelStrategy.cs
+++ b/application/Common/Shared/Events/Queue/Strategy/SingleConsumer/SingleConsumerChannelStrategy.cs
@@ -47,6 +47,13 @@ namespace MORR.Shared.Events.Queue.Strategy.SingleConsumer
             await EnqueueAsync(@event);
         }
 
+        public void NotifyOnEnqueueFinished()
+        {
+            eventChannel.Writer.Complete();
+            FreeReading();
+            eventChannel = CreateChannel();
+        }
+
         private ValueTask EnqueueAsync(TEvent @event)
         {
             async Task AsyncSlowPath(TEvent @event)

--- a/application/Common/Shared/Events/Queue/SupportDeserializationEventQueue.cs
+++ b/application/Common/Shared/Events/Queue/SupportDeserializationEventQueue.cs
@@ -23,5 +23,10 @@ namespace MORR.Shared.Events.Queue
 
             base.Enqueue(typedEvent);
         }
+
+        public new void NotifyOnEnqueueFinished()
+        {
+            base.NotifyOnEnqueueFinished();
+        }
     }
 }

--- a/application/Core/MORR/Data/Capture/Video/Desktop/VideoSampleProducer.cs
+++ b/application/Core/MORR/Data/Capture/Video/Desktop/VideoSampleProducer.cs
@@ -37,18 +37,17 @@ namespace MORR.Core.Data.Capture.Video.Desktop
             closedEvent.Set();
             canCleanupNonPersistentResourcesEvent.WaitOne();
             CleanupSessionResources();
+            NotifyOnEnqueueFinished();
         }
 
         private void EnqueueFrames()
         {
             DirectXVideoSample? currentSample;
 
-            do
+            while ((currentSample = GetNextFrame()) != null)
             {
-                currentSample = GetNextFrame();
-                Enqueue(currentSample); // Intentionally enqueue null to stop encoder
+                Enqueue(currentSample);
             }
-            while (currentSample != null);
         }
 
         private DirectXVideoSample? GetNextFrame()

--- a/application/Core/MORR/Data/IntermediateFormat/Json/JsonIntermediateFormatDeserializer.cs
+++ b/application/Core/MORR/Data/IntermediateFormat/Json/JsonIntermediateFormatDeserializer.cs
@@ -51,6 +51,8 @@ namespace MORR.Core.Data.IntermediateFormat.Json
                     eventQueue.Enqueue(@event);
                 }
             }
+
+            eventQueue.NotifyOnEnqueueFinished();
         }
     }
 }

--- a/application/Core/MORR/Data/IntermediateFormat/Json/JsonIntermediateFormatSerializer.cs
+++ b/application/Core/MORR/Data/IntermediateFormat/Json/JsonIntermediateFormatSerializer.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using MORR.Shared.Events;
 using MORR.Shared.Events.Queue;
@@ -15,6 +17,8 @@ namespace MORR.Core.Data.IntermediateFormat.Json
     {
         private bool isActive;
 
+        private CountdownEvent resetCounter;
+
         [ImportMany]
         private IEnumerable<IReadOnlyEventQueue<Event>> EventQueues { get; set; }
 
@@ -23,16 +27,15 @@ namespace MORR.Core.Data.IntermediateFormat.Json
         public bool IsActive
         {
             get => isActive;
-            set => Utility.SetAndDispatch(ref isActive, value, LinkAllQueues, delegate
-            {
-                /* TODO Cancel iteration */
-            });
+            set => Utility.SetAndDispatch(ref isActive, value, LinkAllQueues, () => { });
         }
 
         public Guid Identifier { get; } = new Guid("2D61FFB2-9CC1-4AAD-B1B9-A362FCF022A0");
 
         private void LinkAllQueues()
         {
+            resetCounter = new CountdownEvent(EventQueues.Count());
+
             foreach (var eventQueue in EventQueues)
             {
                 Task.Run(() => LinkSingleQueue(eventQueue));
@@ -64,9 +67,13 @@ namespace MORR.Core.Data.IntermediateFormat.Json
         {
             await foreach (var @event in eventQueue.GetEvents())
             {
-                // TODO Cancel iteration once module is deactivated
                 var sample = MakeSample(@event);
                 Enqueue(sample);
+            }
+
+            if (resetCounter.Signal())
+            {
+                NotifyOnEnqueueFinished();
             }
         }
     }

--- a/application/Core/MORR/Data/Transcoding/IDecoder.cs
+++ b/application/Core/MORR/Data/Transcoding/IDecoder.cs
@@ -1,4 +1,5 @@
-﻿using MORR.Shared.Utility;
+﻿using System.Threading;
+using MORR.Shared.Utility;
 
 namespace MORR.Core.Data.Transcoding
 {
@@ -7,6 +8,11 @@ namespace MORR.Core.Data.Transcoding
     /// </summary>
     public interface IDecoder
     {
+        /// <summary>
+        ///     An event raised when decoding finishes.
+        /// </summary>
+        ManualResetEvent DecodeFinished { get; }
+
         /// <summary>
         ///     Decodes the recording and provides the decoded samples.
         /// </summary>

--- a/application/Core/MORR/Data/Transcoding/IEncoder.cs
+++ b/application/Core/MORR/Data/Transcoding/IEncoder.cs
@@ -1,4 +1,5 @@
-﻿using MORR.Shared.Utility;
+﻿using System.Threading;
+using MORR.Shared.Utility;
 
 namespace MORR.Core.Data.Transcoding
 {
@@ -7,6 +8,11 @@ namespace MORR.Core.Data.Transcoding
     /// </summary>
     public interface IEncoder
     {
+        /// <summary>
+        ///     An event raised when encoding finishes.
+        /// </summary>
+        ManualResetEvent EncodeFinished { get; }
+
         /// <summary>
         ///     Encodes the provided samples to a file.
         /// </summary>

--- a/application/Core/MORR/Data/Transcoding/Json/JsonDecoder.cs
+++ b/application/Core/MORR/Data/Transcoding/Json/JsonDecoder.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.Composition;
 using System.IO;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using MORR.Core.Data.IntermediateFormat.Json;
 using MORR.Core.Data.Transcoding.Exceptions;
@@ -17,6 +18,8 @@ namespace MORR.Core.Data.Transcoding.Json
         private JsonDecoderConfiguration Configuration { get; set; }
 
         private static Guid Identifier { get; } = new Guid("E943EACB-5AD1-49A7-92CE-C42E7AD8995B");
+
+        public ManualResetEvent DecodeFinished { get; } = new ManualResetEvent(false);
 
         public void Decode(DirectoryPath recordingDirectoryPath)
         {
@@ -33,6 +36,8 @@ namespace MORR.Core.Data.Transcoding.Json
         {
             await using var fileStream = GetFileStream(recordingDirectoryPath);
             var document = JsonDocument.Parse(fileStream).RootElement;
+
+            DecodeFinished.Reset();
 
             foreach (var eventElement in document.EnumerateArray())
             {
@@ -58,6 +63,7 @@ namespace MORR.Core.Data.Transcoding.Json
             }
 
             NotifyOnEnqueueFinished();
+            DecodeFinished.Set();
         }
     }
 }

--- a/application/Core/MORR/Data/Transcoding/Json/JsonDecoder.cs
+++ b/application/Core/MORR/Data/Transcoding/Json/JsonDecoder.cs
@@ -56,6 +56,8 @@ namespace MORR.Core.Data.Transcoding.Json
 
                 Enqueue(intermediateFormatSample);
             }
+
+            NotifyOnEnqueueFinished();
         }
     }
 }

--- a/application/Core/MORR/Data/Transcoding/MPEG/MPEGEncoder.cs
+++ b/application/Core/MORR/Data/Transcoding/MPEG/MPEGEncoder.cs
@@ -96,6 +96,11 @@ namespace MORR.Core.Data.Transcoding.Mpeg
                 nextSample = videoSample;
                 nextSampleReady.Set();
             }
+
+            // Stop encoding by sending null sample
+            sampleProcessed.WaitOne();
+            nextSample = null;
+            nextSampleReady.Set();
         }
 
         #region Transcoder setup

--- a/application/Core/MORR/Data/Transcoding/MPEG/MPEGEncoder.cs
+++ b/application/Core/MORR/Data/Transcoding/MPEG/MPEGEncoder.cs
@@ -28,6 +28,8 @@ namespace MORR.Core.Data.Transcoding.Mpeg
         [Import]
         private IEncodeableEventQueue<DirectXVideoSample> VideoQueue { get; set; }
 
+        public ManualResetEvent EncodeFinished { get; } = new ManualResetEvent(false);
+
         public void Encode(DirectoryPath recordingDirectoryPath)
         {
             encodingStart = DateTime.Now;
@@ -59,6 +61,7 @@ namespace MORR.Core.Data.Transcoding.Mpeg
 
             await using var destinationFile = GetFileStream(recordingDirectoryPath);
 
+            EncodeFinished.Reset();
             var prepareTranscodeResult =
                 await transcoder.PrepareMediaStreamSourceTranscodeAsync(
                     mediaStreamSource, destinationFile.AsRandomAccessStream(), encodingProfile);
@@ -69,7 +72,7 @@ namespace MORR.Core.Data.Transcoding.Mpeg
                     $"Failed to start transcoding operation. Reason: {prepareTranscodeResult.FailureReason}");
             }
 
-            await prepareTranscodeResult.TranscodeAsync();
+            await prepareTranscodeResult.TranscodeAsync().AsTask().ContinueWith(_ => EncodeFinished.Set());
         }
 
         private async Task ConsumeVideoSamples()

--- a/application/Core/MORR/Session/SessionConfiguration.cs
+++ b/application/Core/MORR/Session/SessionConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using MORR.Core.Configuration;
@@ -10,14 +11,14 @@ namespace MORR.Core.Session
     public class SessionConfiguration : IConfiguration
     {
         /// <summary>
-        ///     The type of the encoder to use.
+        ///     The types of the encoders to use.
         /// </summary>
-        public Type Encoder { get; private set; }
+        public IEnumerable<Type> Encoders { get; private set; }
 
         /// <summary>
-        ///     The type of the decoder to use.
+        ///     The types of the decoders to use.
         /// </summary>
-        public Type? Decoder { get; private set; }
+        public IEnumerable<Type>? Decoders { get; private set; }
 
         /// <summary>
         ///     The directory in which to store new recordings.
@@ -28,24 +29,42 @@ namespace MORR.Core.Session
         {
             var element = JsonDocument.Parse(configuration.RawValue).RootElement;
 
-            if (!element.TryGetProperty(nameof(Encoder), out var encoderElement) ||
-                !TryGetType(encoderElement, out var encoder))
+            var encoders = new List<Type>();
+
+            if (!element.TryGetProperty(nameof(Encoders), out var encodersElement))
             {
-                throw new InvalidConfigurationException("Failed to parse encoder type.");
+                throw new InvalidConfigurationException("Failed to parse encoders property.");
             }
 
-            Encoder = encoder;
-
-            Type? decoder = null;
-
-            // Specifying a decoder is optional; only thrown an error if a value was specified but could not be parsed
-            if (element.TryGetProperty(nameof(Decoder), out var decoderElement) &&
-                !TryGetType(decoderElement, out decoder))
+            foreach (var encoderElement in encodersElement.EnumerateArray())
             {
-                throw new InvalidConfigurationException("Failed to parse decoder type.");
+                if (!TryGetType(encoderElement, out var encoder))
+                {
+                    throw new InvalidConfigurationException("Failed to parse encoder type.");
+                }
+
+                encoders.Add(encoder);
             }
 
-            Decoder = decoder;
+            Encoders = encoders;
+
+            // Specifying a decoder is optional; do not throw an error if the property does not exist
+            if (element.TryGetProperty(nameof(Decoders), out var decodersElement))
+            {
+                var decoders = new List<Type>();
+
+                foreach (var decoderElement in decodersElement.EnumerateArray())
+                {
+                    if (!TryGetType(decoderElement, out var decoder))
+                    {
+                        throw new InvalidConfigurationException("Failed to parse decoder type.");
+                    }
+
+                    decoders.Add(decoder);
+                }
+
+                Decoders = decoders;
+            }
 
             if (!element.TryGetProperty(nameof(RecordingDirectory), out var directoryElement))
             {

--- a/application/Core/MORR/Session/SessionManager.cs
+++ b/application/Core/MORR/Session/SessionManager.cs
@@ -13,8 +13,8 @@ namespace MORR.Core.Session
 {
     public class SessionManager : ISessionManager
     {
-        private readonly IDecoder? decoder;
-        private readonly IEncoder encoder;
+        private readonly IEnumerable<IEncoder> encoders;
+        private readonly IEnumerable<IDecoder> decoders;
         private readonly IModuleManager moduleManager;
         private bool isRecording;
 
@@ -33,8 +33,8 @@ namespace MORR.Core.Session
 
             configurationManager.LoadConfiguration(configurationPath);
 
-            encoder = Encoders.Single(x => x.GetType() == Configuration.Encoder);
-            decoder = Decoders.SingleOrDefault(x => x.GetType() == Configuration.Decoder);
+            encoders = Encoders.Where(x => Configuration.Encoders.Contains(x.GetType()));
+            decoders = Decoders.Where(x => Configuration.Decoders?.Contains(x.GetType()) ?? false);
 
             moduleManager.InitializeModules();
         }
@@ -69,7 +69,11 @@ namespace MORR.Core.Session
 
             CurrentRecordingDirectory = CreateNewRecordingDirectory();
 
-            encoder.Encode(CurrentRecordingDirectory);
+            foreach (var encoder in encoders)
+            {
+                encoder.Encode(CurrentRecordingDirectory);
+            }
+
             moduleManager.NotifyModulesOnSessionStart();
         }
 
@@ -83,12 +87,18 @@ namespace MORR.Core.Session
             isRecording = false;
 
             moduleManager.NotifyModulesOnSessionStop();
-            encoder.EncodeFinished.WaitOne();
+
+            foreach (var encoder in encoders)
+            {
+                // IEncoder.EncodeFinished will not be reset before IEncoder.Encode gets called again
+                // We may therefore wait on this event sequentially without risk of blocking indefinitely
+                encoder.EncodeFinished.WaitOne();
+            }
         }
 
         public void Process(IEnumerable<DirectoryPath> recordings)
         {
-            if (decoder == null)
+            if (!decoders.Any())
             {
                 throw new InvalidConfigurationException("No decoder specified for processing operation.");
             }
@@ -98,11 +108,26 @@ namespace MORR.Core.Session
             foreach (var recording in recordings)
             {
                 CurrentRecordingDirectory = CreateNewRecordingDirectory();
-                decoder.Decode(recording);
-                encoder.Encode(CurrentRecordingDirectory);
 
-                decoder.DecodeFinished.WaitOne();
-                encoder.EncodeFinished.WaitOne();
+                foreach (var decoder in decoders)
+                {
+                    decoder.Decode(recording);
+                }
+
+                foreach (var encoder in encoders)
+                {
+                    encoder.Encode(CurrentRecordingDirectory);
+                }
+
+                foreach (var decoder in decoders)
+                {
+                    decoder.DecodeFinished.WaitOne();
+                }
+
+                foreach (var encoder in encoders)
+                {
+                    encoder.EncodeFinished.WaitOne();
+                }
             }
 
             moduleManager.NotifyModulesOnSessionStop();

--- a/application/Core/MORR/Session/SessionManager.cs
+++ b/application/Core/MORR/Session/SessionManager.cs
@@ -83,6 +83,7 @@ namespace MORR.Core.Session
             isRecording = false;
 
             moduleManager.NotifyModulesOnSessionStop();
+            encoder.EncodeFinished.WaitOne();
         }
 
         public void Process(IEnumerable<DirectoryPath> recordings)
@@ -99,6 +100,9 @@ namespace MORR.Core.Session
                 CurrentRecordingDirectory = CreateNewRecordingDirectory();
                 decoder.Decode(recording);
                 encoder.Encode(CurrentRecordingDirectory);
+
+                decoder.DecodeFinished.WaitOne();
+                encoder.EncodeFinished.WaitOne();
             }
 
             moduleManager.NotifyModulesOnSessionStop();

--- a/application/Modules/Clipboard/Producers/ClipboardCopyEventProducer.cs
+++ b/application/Modules/Clipboard/Producers/ClipboardCopyEventProducer.cs
@@ -160,6 +160,7 @@ namespace MORR.Modules.Clipboard.Producers
         public void StopCapture()
         {
             clipboardWindowMessageSink?.Dispose();
+            NotifyOnEnqueueFinished();
         }
 
         #endregion

--- a/application/Modules/Clipboard/Producers/ClipboardCutEventProducer.cs
+++ b/application/Modules/Clipboard/Producers/ClipboardCutEventProducer.cs
@@ -19,6 +19,7 @@ namespace MORR.Modules.Clipboard.Producers
         public void StopCapture()
         {
             GlobalHook.RemoveListener(GlobalHookCallBack, NativeMethods.MessageType.WM_CUT);
+            NotifyOnEnqueueFinished();
         }
 
 

--- a/application/Modules/Clipboard/Producers/ClipboardPasteEventProducer.cs
+++ b/application/Modules/Clipboard/Producers/ClipboardPasteEventProducer.cs
@@ -19,6 +19,7 @@ namespace MORR.Modules.Clipboard.Producers
         public void StopCapture()
         {
             GlobalHook.RemoveListener(GlobalHookCallBack, NativeMethods.MessageType.WM_PASTE);
+            NotifyOnEnqueueFinished();
         }
 
 

--- a/application/Modules/Keyboard/Producers/KeyboardInteractEventProducer.cs
+++ b/application/Modules/Keyboard/Producers/KeyboardInteractEventProducer.cs
@@ -29,6 +29,8 @@ namespace MORR.Modules.Keyboard.Producers
             {
                 throw new Exception("Failed to unhook keyboard.");
             }
+
+            NotifyOnEnqueueFinished();
         }
 
         private int KeyboardHookCallback(int nCode,

--- a/application/Modules/Mouse/Producers/MouseClickEventProducer.cs
+++ b/application/Modules/Mouse/Producers/MouseClickEventProducer.cs
@@ -43,6 +43,7 @@ namespace MORR.Modules.Mouse.Producers
                                       NativeMethods.MessageType.WM_NCRBUTTONDBLCLK,
                                       NativeMethods.MessageType.WM_NCLBUTTONDBLCLK,
                                       NativeMethods.MessageType.WM_NCMBUTTONDBLCLK);
+            NotifyOnEnqueueFinished();
         }
 
         private void MouseHookCallback(GlobalHook.HookMessage hookMessage)

--- a/application/Modules/Mouse/Producers/MouseMoveEventProducer.cs
+++ b/application/Modules/Mouse/Producers/MouseMoveEventProducer.cs
@@ -82,6 +82,7 @@ namespace MORR.Modules.Mouse.Producers
         public void StopCapture()
         {
             mousePositionRecordingTimer?.Dispose();
+            NotifyOnEnqueueFinished();
         }
     }
 }

--- a/application/Modules/Mouse/Producers/MouseScrollEventProducer.cs
+++ b/application/Modules/Mouse/Producers/MouseScrollEventProducer.cs
@@ -19,6 +19,7 @@ namespace MORR.Modules.Mouse.Producers
         public void StopCapture()
         {
             GlobalHook.RemoveListener(MouseHookCallback, NativeMethods.MessageType.WM_MOUSEWHEEL);
+            NotifyOnEnqueueFinished();
         }
 
         private void MouseHookCallback(GlobalHook.HookMessage hookMessage)

--- a/application/Modules/WebBrowser/IWebBrowserEventObserver.cs
+++ b/application/Modules/WebBrowser/IWebBrowserEventObserver.cs
@@ -6,6 +6,7 @@ namespace MORR.Modules.WebBrowser
     {
         public EventLabel HandledEventLabel { get; }
         public void Notify(JsonElement eventJson);
+        public void EnqueueFinished();
     }
 
     internal interface IWebBrowserEventObservable

--- a/application/Modules/WebBrowser/Producers/WebBrowserEventProducer.cs
+++ b/application/Modules/WebBrowser/Producers/WebBrowserEventProducer.cs
@@ -23,6 +23,14 @@ namespace MORR.Modules.WebBrowser.Producers
         }
 
         /// <summary>
+        ///     Lets consumers know that no more events will be enqueued.
+        /// </summary>
+        public void EnqueueFinished()
+        {
+            NotifyOnEnqueueFinished();
+        }
+
+        /// <summary>
         ///     The BrowserEvent label to be handled by this producer.
         /// </summary>
         public virtual EventLabel HandledEventLabel => throw new NotSupportedException("Cannot get property from abstract WebBrowserEventProducer");

--- a/application/Modules/WebBrowser/WebBrowserModule.cs
+++ b/application/Modules/WebBrowser/WebBrowserModule.cs
@@ -43,7 +43,16 @@ namespace MORR.Modules.WebBrowser
             get => isActive;
             set => Utility.SetAndDispatch(ref isActive, value,
                                           () => listener.RecordingActive = true,
-                                          () => listener.RecordingActive = false);
+                                          StopRecording);
+        }
+
+        private void StopRecording()
+        {
+            listener.RecordingActive = false;
+            foreach (var producer in producers)
+            {
+                producer.EnqueueFinished();
+            }
         }
 
         public void Initialize()


### PR DESCRIPTION
Closes #88 

## Potential issues

As a limitation of the way our module loading mechanism and the mechanism to notify consumers when producers have finished producing events work together, the application will not terminate properly if modules are loaded (are in the Modules subdirectory), but are disabled in the configuration, as no event will be sent when capturing stops.