### PR TITLE
Enable recording mappedCharacter to the Event

### DIFF
--- a/application/Modules/Keyboard/Events/KeyboardInteractEvent.cs
+++ b/application/Modules/Keyboard/Events/KeyboardInteractEvent.cs
@@ -9,18 +9,36 @@ namespace MORR.Modules.Keyboard.Events
     public class KeyboardInteractEvent : KeyboardEvent
     {
         /// <summary>
-        ///     The key that was pressed
+        ///     The key that was pressed.
+        ///     This field is for data processing.
         /// </summary>
-        public Key PressedKey { get; set; }
+        public Key PressedKey_System_Windows_Input_Key { get; set; }
 
         /// <summary>
-        ///     The modifier keys to the key pressed
+        ///     The name of the key on the keyboard that is pressed
+        ///     This field is only for increasing the human readability. 
         /// </summary>
-        public ModifierKeys ModifierKeys { get; set; }
+        public string PressedKeyName { get; set; }
 
         /// <summary>
-        ///     The actual user input according to Input locale
+        ///     The modifier keys to the key pressed.
+        ///     This field is for data processing
         /// </summary>
-        public char MappedCharacter { get; set; }
+        public ModifierKeys ModifierKeys_System_Windows_Input_ModifierKeys { get; set; }
+
+        /// <summary>
+        ///     The name of the key on the keyboard that is pressed
+        ///     This field is only for increasing the human readability. 
+        /// </summary>
+        public string ModifierKeysName { get; set; }
+
+        /// <summary>
+        ///     The actual user input according to Input locale.
+        ///     If the event has '\u0000' at this property, the
+        ///     pressed key is not mapped to a unicode. It can
+        ///     be Shift, Alt etc.
+        ///     This field is only for increasing the human readability.
+        /// </summary>
+        public char MappedCharacter_Unicode { get; set; }
     }
 }

--- a/application/Modules/Keyboard/Events/KeyboardInteractEvent.cs
+++ b/application/Modules/Keyboard/Events/KeyboardInteractEvent.cs
@@ -17,5 +17,10 @@ namespace MORR.Modules.Keyboard.Events
         ///     The modifier keys to the key pressed
         /// </summary>
         public ModifierKeys ModifierKeys { get; set; }
+
+        /// <summary>
+        ///     The actual user input according to Input locale
+        /// </summary>
+        public char MappedCharacter { get; set; }
     }
 }

--- a/application/Modules/Keyboard/Native/INativeKeyboard.cs
+++ b/application/Modules/Keyboard/Native/INativeKeyboard.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Text;
 using MORR.Shared.Hook;
 
 namespace MORR.Modules.Keyboard.Native
@@ -18,6 +19,7 @@ namespace MORR.Modules.Keyboard.Native
             VK_SHIFT = 0x10,
             VK_CONTROL = 0x11,
             VK_MENU = 0x12,
+            VK_CAPITAL = 0x14,
             VK_LWIN = 0x5B,
             VK_RWIN = 0x5C
         }
@@ -32,13 +34,21 @@ namespace MORR.Modules.Keyboard.Native
 
         bool TrySetKeyboardHook(LowLevelKeyboardProc callback, out IntPtr handle);
 
+        IntPtr GetKeyboardLayout(uint idThread);
+
+        int ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[]
+   lpKeyState, [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pwszBuff,
+   int cchBuff, uint wFlags, IntPtr dwhkl);
+
+        bool GetKeyboardState(byte[] lpKeyState);
+
         public struct KBDLLHOOKSTRUCT
         {
-            public int VKCode;
-            public int ScanCode;
-            public int Flags;
-            public int Time;
-            public int DWExtraInfo;
+            public uint VKCode;
+            public uint ScanCode;
+            public uint Flags;
+            public uint Time;
+            public uint DWExtraInfo;
         }
     }
 }

--- a/application/Modules/Keyboard/Native/NativeKeyboard.cs
+++ b/application/Modules/Keyboard/Native/NativeKeyboard.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text;
 using MORR.Shared.Hook;
 
 namespace MORR.Modules.Keyboard.Native
@@ -70,6 +71,20 @@ namespace MORR.Modules.Keyboard.Native
             return SetWindowsHookEx(hookType, lpFn, hMod, dwThreadId);
         }
 
+        IntPtr INativeKeyboard.GetKeyboardLayout(uint idThread) { return GetKeyboardLayout(idThread);}
+
+        int INativeKeyboard.ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[]
+        lpKeyState, [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pwszBuff,
+        int cchBuff, uint wFlags, IntPtr dwhkl)
+        {
+            return ToUnicodeEx(wVirtKey, wScanCode, lpKeyState, pwszBuff, cchBuff, wFlags, dwhkl
+                );
+        }
+
+        bool INativeKeyboard.GetKeyboardState(byte[] lpKeyState) {
+            return GetKeyboardState(lpKeyState);
+        }
+
         private bool TryGetCurrentModuleHandle(out IntPtr handle)
         {
             using var currentProcess = Process.GetCurrentProcess();
@@ -107,6 +122,18 @@ namespace MORR.Modules.Keyboard.Native
 
         [DllImport("kernel32.dll")]
         private static extern IntPtr GetModuleHandle(string lpModuleName);
+
+        [DllImport("user32.dll")]
+        static extern IntPtr GetKeyboardLayout(uint idThread);
+
+        [DllImport("user32.dll")]
+        static extern int ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[]
+   lpKeyState, [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pwszBuff,
+   int cchBuff, uint wFlags, IntPtr dwhkl);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool GetKeyboardState(byte[] lpKeyState);
 
         #endregion
     }

--- a/application/Modules/Keyboard/Producers/KeyboardInteractEventProducer.cs
+++ b/application/Modules/Keyboard/Producers/KeyboardInteractEventProducer.cs
@@ -66,10 +66,12 @@ namespace MORR.Modules.Keyboard.Producers
 
                 var keyboardEvent = new KeyboardInteractEvent
                 {
-                    MappedCharacter = key,
-                    PressedKey = pressedKey,
-                    ModifierKeys = modifierKeys,
-                    IssuingModule = KeyboardModule.Identifier
+                    MappedCharacter_Unicode = key,
+                    PressedKey_System_Windows_Input_Key = pressedKey,
+                    ModifierKeys_System_Windows_Input_ModifierKeys = modifierKeys,
+                    IssuingModule = KeyboardModule.Identifier,
+                    PressedKeyName = pressedKey.ToString(),
+                    ModifierKeysName = modifierKeys.ToString()
                 };
                 Enqueue(keyboardEvent);
             }

--- a/application/Modules/Keyboard/Producers/KeyboardInteractEventProducer.cs
+++ b/application/Modules/Keyboard/Producers/KeyboardInteractEventProducer.cs
@@ -15,7 +15,7 @@ namespace MORR.Modules.Keyboard.Producers
         private static INativeKeyboard nativeKeyboard;
         private INativeKeyboard.LowLevelKeyboardProc? callback;
         private IntPtr keyboardHookHandle;
-
+        
         public void StartCapture(INativeKeyboard nativeKb)
         {
             nativeKeyboard = nativeKb;
@@ -50,23 +50,32 @@ namespace MORR.Modules.Keyboard.Producers
             if (wParam == GlobalHook.MessageType.WM_KEYDOWN)
             {
                 var virtualKeyCode = lParam.VKCode;
-                var pressedKey = KeyInterop.KeyFromVirtualKey(virtualKeyCode);
-
+                var pressedKey = KeyInterop.KeyFromVirtualKey((int)virtualKeyCode);
                 var modifierKeys = GetModifierKeys();
+
+                byte[] keyState = new byte[256];
+                nativeKeyboard.GetKeyboardState(keyState);
+                System.Text.StringBuilder sbString = new System.Text.StringBuilder(256);
+
+                nativeKeyboard.ToUnicodeEx((uint)(lParam.VKCode),
+                    0, keyState, sbString, sbString.Capacity, 0, IntPtr.Zero);
+
+                string keyString = sbString.ToString();
+                char key = '\0';
+                if(!String.IsNullOrEmpty(keyString)) key = sbString.ToString()[0];
 
                 var keyboardEvent = new KeyboardInteractEvent
                 {
+                    MappedCharacter = key,
                     PressedKey = pressedKey,
                     ModifierKeys = modifierKeys,
                     IssuingModule = KeyboardModule.Identifier
                 };
-
                 Enqueue(keyboardEvent);
             }
-
             return nativeKeyboard.CallNextHookEx(IntPtr.Zero, nCode, wParam, lParam);
         }
-
+       
         private static ModifierKeys GetModifierKeys()
         {
             var modifierKeys = ModifierKeys.None;
@@ -91,7 +100,6 @@ namespace MORR.Modules.Keyboard.Producers
             {
                 modifierKeys |= ModifierKeys.Windows;
             }
-
             return modifierKeys;
         }
     }

--- a/application/Modules/Keyboard/Producers/KeyboardInteractEventProducer.cs
+++ b/application/Modules/Keyboard/Producers/KeyboardInteractEventProducer.cs
@@ -47,7 +47,7 @@ namespace MORR.Modules.Keyboard.Producers
                 return nativeKeyboard.CallNextHookEx(IntPtr.Zero, nCode, wParam, lParam);
             }
 
-            if (wParam == GlobalHook.MessageType.WM_KEYDOWN)
+            if(wParam == GlobalHook.MessageType.WM_KEYDOWN || wParam == GlobalHook.MessageType.WM_SYSKEYDOWN)
             {
                 var virtualKeyCode = lParam.VKCode;
                 var pressedKey = KeyInterop.KeyFromVirtualKey((int)virtualKeyCode);


### PR DESCRIPTION
<H3>New feature</H3>
A new property char MappedCharacter is added to the KeyboardInteractEvent.

<H3>Warning! Do not switch language while using the program or testing!</H3>
The MappedCharacter is translated from the virtual keycode from the hook.
I have tested both the low-level hook and the global hook and found out the virtual
keycodes given by both the hook procedure are wrong for the non 0-9 a-z and A-Z 
keys after language change.

For example:
the user enters the program with Language English, user types 'A' and the MappedCharacter
records 'A', user switches to german, types 'b' and MappedCharacter records 'b', but then user types
'ü' and the MappedCharacter records something wrong due to the wrong vkCode given by the hook. User now switches back to English, everything works well again.
If the user starts with german, the german part is ok, and the english part is broken 
for the non 0-9 a-z and A-Z keys.
I can do nothing about this as long as we are relying on hooks.