### PR TITLE
Add webextension unittests

### DIFF
--- a/application/BrowserExtension/package-lock.json
+++ b/application/BrowserExtension/package-lock.json
@@ -772,6 +772,24 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/polyfill": {
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.8.7.tgz",
+      "integrity": "sha512-LeSfP9bNZH2UOZgcGcZ0PIHUt1ZuHub1L3CVmEyqLxCeDLm4C5Gi8jRH8ZX2PNpDhQCo0z6y/+DIs2JlliXW8w==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.4",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
+          "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==",
+          "dev": true
+        }
+      }
+    },
     "@babel/preset-env": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.4.tgz",

--- a/application/BrowserExtension/package.json
+++ b/application/BrowserExtension/package.json
@@ -20,6 +20,7 @@
     "chrome >= 57"
   ],
   "devDependencies": {
+    "@babel/polyfill": "^7.8.7",
     "@types/chrome": "0.0.91",
     "@types/jest": "^24.0.25",
     "@types/node": "^13.1.1",

--- a/application/BrowserExtension/src/__tests__/BackgroundScript.test.ts
+++ b/application/BrowserExtension/src/__tests__/BackgroundScript.test.ts
@@ -25,6 +25,7 @@ beforeEach(() => {
     jest.mock('../ListenerManager')
 })
 
+//Check if invoking run calls the correct functions on the communication interface mock
 test("Regular run", (done) => {
     setUpCommonMocks();
     let startAllMock = ListenerManager.prototype.startAll = jest.fn();
@@ -40,7 +41,7 @@ test("Regular run", (done) => {
     }, WAITTIME);
 })
 
-//Check if invoking run calls the correct function on the Communication Interface mock.
+//Check if backgroundscript takes appropriate action when its stop-callback is invoked
 test("Run stop", (done) => {
     setUpCommonMocks();
     let stopcallback : (error? : boolean) => void;
@@ -75,7 +76,7 @@ test("Run stop", (done) => {
     })
 })
 
-//Check if invoking run calls the correct function on the Communication Interface mock.
+//Check if backgroundscript takes appropriate action when its stop-callback is invoked with an errorstatus
 test("Run stop on error", (done) => {
     setUpCommonMocks();
     let stopcallback : (error? : boolean) => void;

--- a/application/BrowserExtension/src/__tests__/BackgroundScript.test.ts
+++ b/application/BrowserExtension/src/__tests__/BackgroundScript.test.ts
@@ -1,0 +1,129 @@
+import { chrome, resetChrome } from '../__mock__/chrome_mock'
+const globalAny:any = global;
+globalAny.chrome = chrome
+import BackgroundScript from '../background'
+import PostHTTPInterface from '../ApplicationInterface/PostHTTPInterface'
+import ListenerManager from '../ListenerManager'
+
+let bgscript : BackgroundScript;
+
+//Suppress console output for tests
+let log = () => undefined;
+globalAny.console.log = log;
+globalAny.console.error = log;
+
+let connectionMock : any;
+let configMock : any;
+let waitStartMock : any;
+let sendDataMock : any;
+
+const WAITTIME = 30; //how long to wait before counting callback-invocations
+
+beforeEach(() => {
+    jest.resetAllMocks();
+    jest.mock('../ApplicationInterface/PostHTTPInterface')
+    jest.mock('../ListenerManager')
+})
+
+test("Regular run", (done) => {
+    setUpCommonMocks();
+    let startAllMock = ListenerManager.prototype.startAll = jest.fn();
+    bgscript = new BackgroundScript();
+    bgscript.run();
+    setTimeout(() => {
+        expect(connectionMock).toBeCalledTimes(1);
+        expect(waitStartMock).toBeCalledTimes(1);
+        expect(configMock).toBeCalledTimes(1);
+        expect(startAllMock).toBeCalledTimes(1);
+        expect(sendDataMock).toBeCalledTimes(0);
+        done();
+    }, WAITTIME);
+})
+
+//Check if invoking run calls the correct function on the Communication Interface mock.
+test("Run stop", (done) => {
+    setUpCommonMocks();
+    let stopcallback : (error? : boolean) => void;
+    let onStopListenerCallback = PostHTTPInterface.prototype.addOnStopListener = jest.fn((...args: any[]) => {stopcallback = args[0];});
+    let startAllMock = ListenerManager.prototype.startAll = jest.fn();
+    let stopAllMock = ListenerManager.prototype.stopAll = jest.fn();
+    bgscript = new BackgroundScript();
+    bgscript.run();
+    new Promise((resolve) => {
+        setTimeout(() => {
+            expect(connectionMock).toBeCalledTimes(1);
+            expect(waitStartMock).toBeCalledTimes(1);
+            expect(configMock).toBeCalledTimes(1);
+            expect(onStopListenerCallback).toBeCalledTimes(1);
+            expect(startAllMock).toBeCalledTimes(1);
+            expect(stopAllMock).toBeCalledTimes(0);
+            expect(sendDataMock).toBeCalledTimes(0);
+            expect(stopcallback).not.toBeUndefined();
+            stopcallback();
+            resolve();
+        }, WAITTIME);
+    })
+    .then(() => {
+        setTimeout(() => {
+            expect(connectionMock).toBeCalledTimes(1);
+            expect(waitStartMock).toBeCalledTimes(2);
+            expect(configMock).toBeCalledTimes(1);
+            expect(sendDataMock).toBeCalledTimes(0);
+            expect(stopAllMock).toBeCalledTimes(1);
+            done();
+        }, WAITTIME);
+    })
+})
+
+//Check if invoking run calls the correct function on the Communication Interface mock.
+test("Run stop on error", (done) => {
+    setUpCommonMocks();
+    let stopcallback : (error? : boolean) => void;
+    let onStopListenerCallback = PostHTTPInterface.prototype.addOnStopListener = jest.fn((...args: any[]) => {stopcallback = args[0];});
+    let startAllMock = ListenerManager.prototype.startAll = jest.fn();
+    let stopAllMock = ListenerManager.prototype.stopAll = jest.fn();
+    bgscript = new BackgroundScript();
+    bgscript.run();
+    new Promise((resolve) => {
+        setTimeout(() => {
+            expect(connectionMock).toBeCalledTimes(1);
+            expect(waitStartMock).toBeCalledTimes(1);
+            expect(configMock).toBeCalledTimes(1);
+            expect(onStopListenerCallback).toBeCalledTimes(1);
+            expect(startAllMock).toBeCalledTimes(1);
+            expect(stopAllMock).toBeCalledTimes(0);
+            expect(sendDataMock).toBeCalledTimes(0);
+            expect(stopcallback).not.toBeUndefined();
+            jest.useFakeTimers();
+            stopcallback(true);
+            resolve();
+        }, WAITTIME);
+    })
+    .then(() => {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+        setTimeout(() => {
+            expect(connectionMock).toBeCalledTimes(2);
+            expect(configMock).toBeCalledTimes(2);
+            expect(waitStartMock).toBeCalledTimes(2);
+            expect(sendDataMock).toBeCalledTimes(0);
+            expect(stopAllMock).toBeCalledTimes(1);
+            done();
+        }, WAITTIME);
+    })
+})
+
+function setUpCommonMocks() {
+    connectionMock = PostHTTPInterface.prototype.establishConnection = jest.fn().mockImplementation(() => new Promise((resolve) => {
+        resolve();
+    }));
+    configMock = PostHTTPInterface.prototype.requestConfig = jest.fn(() => new Promise<string>((resolve) => {
+        resolve("Some Config");
+    }));
+    waitStartMock = PostHTTPInterface.prototype.waitForStart = jest.fn(() => new Promise((resolve) => {
+        resolve();
+    }));
+    sendDataMock = PostHTTPInterface.prototype.sendData = jest.fn(() => new Promise((resolve) => {
+        resolve();
+    }));
+}

--- a/application/BrowserExtension/src/__tests__/ListenerManager.test.ts
+++ b/application/BrowserExtension/src/__tests__/ListenerManager.test.ts
@@ -1,0 +1,49 @@
+import { chrome, resetChrome } from '../__mock__/chrome_mock'
+import ListenerManager from '../ListenerManager'
+import TabListener from '../Listeners/Tab/TabListener'
+import { BrowserEvent } from '../Shared/SharedDeclarations';
+
+jest.mock('../Listeners/Tab/TabListener')
+
+const WAITTIME = 30; //how long to wait before counting callback-invocations
+const globalAny:any = global;
+const startmock = TabListener.prototype.start = jest.fn();
+const stopmock = TabListener.prototype.stop = jest.fn();
+let manager : ListenerManager;
+
+beforeAll(() => {
+    globalAny.chrome = chrome
+})
+
+beforeEach(() => {
+    manager = new ListenerManager((event : BrowserEvent) => {return;});
+    jest.resetAllMocks();
+})
+
+test("StartAll", () => {
+    manager.startAll();
+    expect(startmock).toHaveBeenCalledTimes(1);
+    expect(stopmock).toHaveBeenCalledTimes(0);
+})
+
+test("Constructor", () => {
+    manager = new ListenerManager((event : BrowserEvent) => {return;});
+})
+
+test("StopAll", () => {
+    manager.startAll();
+    manager.stopAll();
+    expect(startmock).toHaveBeenCalledTimes(1);
+    expect(stopmock).toHaveBeenCalledTimes(1);
+})
+
+test("StartAll (already started)", () => {
+    manager.startAll();
+    manager.startAll();
+    expect(startmock).toHaveBeenCalledTimes(1);
+})
+
+test("StopAll (already stopped)", () => {
+    manager.stopAll();
+    expect(startmock).toHaveBeenCalledTimes(0);
+})

--- a/application/BrowserExtension/src/__tests__/ListenerManager.test.ts
+++ b/application/BrowserExtension/src/__tests__/ListenerManager.test.ts
@@ -20,16 +20,14 @@ beforeEach(() => {
     jest.resetAllMocks();
 })
 
+//check if startall calls start on one of the listeners
 test("StartAll", () => {
     manager.startAll();
     expect(startmock).toHaveBeenCalledTimes(1);
     expect(stopmock).toHaveBeenCalledTimes(0);
 })
 
-test("Constructor", () => {
-    manager = new ListenerManager((event : BrowserEvent) => {return;});
-})
-
+//check if stopall calls stop on one of the listeners
 test("StopAll", () => {
     manager.startAll();
     manager.stopAll();
@@ -37,12 +35,14 @@ test("StopAll", () => {
     expect(stopmock).toHaveBeenCalledTimes(1);
 })
 
+//check if startall does not perform excessive start-calls when called multiple times
 test("StartAll (already started)", () => {
     manager.startAll();
     manager.startAll();
     expect(startmock).toHaveBeenCalledTimes(1);
 })
 
+//check if stopall does not perform excessive stop-calls when called multiple times
 test("StopAll (already stopped)", () => {
     manager.stopAll();
     expect(startmock).toHaveBeenCalledTimes(0);

--- a/application/BrowserExtension/src/__tests__/Listeners/DOM/ContentScript/DOMEventFactory.test.ts
+++ b/application/BrowserExtension/src/__tests__/Listeners/DOM/ContentScript/DOMEventFactory.test.ts
@@ -20,11 +20,6 @@ test("TestSetup", () => {
     expect(document.location.href).toBe(sampleDocument.url);
 })
 
-//nothing to check here really, just for completeness' sake
-test("Constructor", () => {
-    expect(factory).toBeInstanceOf(DOMEventFactory);
-});
-
 //create a ButtonClickEvent (base scenario)
 test("Create ButtonClickEvent (success, type button)", done => {
     factory.createEvent(<Event>(<any>{type : DOMEventTypes.CLICK, target : sampleTarget}))

--- a/application/BrowserExtension/src/__tests__/Listeners/DOM/ContentScript/DOMEventFactory.test.ts
+++ b/application/BrowserExtension/src/__tests__/Listeners/DOM/ContentScript/DOMEventFactory.test.ts
@@ -105,3 +105,44 @@ test("Create HoverEvent (success)", done => {
         }
     });
 });
+
+//create a ButtonClickEvent (base scenario)
+test("Create ButtonClickEvent (no element title)", done => {
+    const basetarget = {tagName : "BUTTON", value : "sampleinput", type : "text",
+    getAttribute : function(attr : string) {return (attr == "href") ? "https://sample.com/redirect" : null;}};
+    const anotherTarget = {...basetarget, name : "element name"};
+    const anotherTarget2 = {...basetarget, id : "element id"};
+    factory.createEvent(<Event>(<any>{type : DOMEventTypes.CLICK, target : anotherTarget}))
+    .then((event? : BrowserEvent) => {
+        expect(event).not.toBeUndefined;
+        if(event) {
+            let sEvent = <ButtonClickEvent>event;
+            expect(sEvent.buttonTitle).toBe(anotherTarget.name);
+            done();
+        } else {
+            fail("event is undefined or of unexpected type");
+            done();
+        }
+    })
+    .catch((e : Error) => {
+        fail(e);
+        done();
+    });
+
+    factory.createEvent(<Event>(<any>{type : DOMEventTypes.CLICK, target : anotherTarget2}))
+    .then((event? : BrowserEvent) => {
+        expect(event).not.toBeUndefined;
+        if(event) {
+            let sEvent = <ButtonClickEvent>event;
+            expect(sEvent.buttonTitle).toBe(anotherTarget2.id);
+            done();
+        } else {
+            fail("event is undefined or of unexpected type");
+            done();
+        }
+    })
+    .catch((e : Error) => {
+        fail(e);
+        done();
+    });
+});

--- a/application/BrowserExtension/src/__tests__/Listeners/DOM/DOMEvents.test.ts
+++ b/application/BrowserExtension/src/__tests__/Listeners/DOM/DOMEvents.test.ts
@@ -4,6 +4,10 @@ import { EventType } from '../../../Shared/SharedDeclarations'
 const sample : any = {_issuingModule : 0, _windowID : 3, _tabID : 7,  _url : new URL("http://sample.com")};
 const sender : chrome.runtime.MessageSender = {tab : ({id : 7, windowId : 3} as chrome.tabs.Tab)} as chrome.runtime.MessageSender;
 
+/**
+ * Check constructors, getters, setters and deserializers of all DOMEvents.
+ */
+
 describe("TextInputEvent Tests", () => {
     const mySample = {...sample};
     mySample._text = "Selected Text";

--- a/application/BrowserExtension/src/__tests__/Listeners/DOM/DOMListener.test.ts
+++ b/application/BrowserExtension/src/__tests__/Listeners/DOM/DOMListener.test.ts
@@ -30,6 +30,9 @@ beforeEach(() => {
     chrome.tabs.query.yields(tabs);
 });
 
+/**
+ * Confirm consturctor working and not invoking the callback.
+ */
 test('Constructor', () => {
     expect(listener).toBeInstanceOf(DOMListener);
     expect(mockCallback).toHaveBeenCalledTimes(0);
@@ -75,7 +78,7 @@ test('Inject script', () => {
 });
 
 /**
- * Test if the listener correctly treats incoming serialized events (sent from contentscript)
+ * The following tests check if the listener correctly treats incoming serialized events (sent from contentscript)
  */
 test('Receive serialized ButtonClickEvent', () => {
     listener.start();

--- a/application/BrowserExtension/src/__tests__/Listeners/Download/DownloadEventFactory.test.ts
+++ b/application/BrowserExtension/src/__tests__/Listeners/Download/DownloadEventFactory.test.ts
@@ -9,10 +9,9 @@ beforeAll(() => {
     globalAny.chrome = chrome
 })
 
-test('Factory Constructor Test', () => {
-    expect(new DownloadEventFactory()).toBeInstanceOf(DownloadEventFactory);
-})
-
+/**
+ * Create a new DownloadEvent
+ */
 test('Create DownloadEvent', async () => {
     let now : Date = new Date();
     let factory : DownloadEventFactory = new DownloadEventFactory();

--- a/application/BrowserExtension/src/__tests__/Listeners/Tab/TabEventFactory.test.ts
+++ b/application/BrowserExtension/src/__tests__/Listeners/Tab/TabEventFactory.test.ts
@@ -10,18 +10,24 @@ beforeAll(() => {
     factory = new TabEventFactory();
 })
 
+/**
+ * Create an OpenTabEvent from the information passed by the browser.
+ */
 test('Create OpenTabEvent', () => {
     let evt : OpenTabEvent = factory.createOpenTabEvent(item as chrome.tabs.Tab);
     expect(evt).toMatchObject({_tabID : item.id, _windowID : item.windowId});
 });
 
-//check if the factory correctly creates an OpenTabEvent if no tabID was created
+//Check if the factory correctly creates an OpenTabEvent if no tabID was created
 test('Create OpenTabEvent no ID', () => {
     let myItem : any = {url : item.url, windowId : item.windowId};
     let evt : OpenTabEvent = factory.createOpenTabEvent(myItem as chrome.tabs.Tab);
     expect(evt).toMatchObject({_tabID : 0, _windowID : item.windowId});
 });
 
+/**
+ * Create a CloseTabEvent from the information passed by the browser.
+ */
 test('Create CloseTabEvent', () => {
     let evt : CloseTabEvent = factory.createCloseTabEvent(item.id, {windowId : item.windowId} as chrome.tabs.TabRemoveInfo, item as chrome.tabs.Tab);
     expect(evt).toMatchObject({_tabID : item.id, _windowID : item.windowId});
@@ -35,6 +41,9 @@ test('Create CloseTabEvent no ID-match', () => {
     expect(evt.url.href).toBe(UNKOWN_URL);
 })
 
+/**
+ * Create a NavigationEvent from the information passed by the browser.
+ */
 test('Create NavigationEvent', () => {
     let evt : NavigationEvent = factory.createNavigationEvent(item.id, {url: item.url} as chrome.tabs.TabChangeInfo, item as chrome.tabs.Tab);
     expect(evt).toMatchObject({_tabID : item.id, _windowID : item.windowId});
@@ -46,6 +55,9 @@ test('Create NavigationEvent missing URL', () => {
     expect(() => factory.createNavigationEvent(item.id, {} as chrome.tabs.TabChangeInfo, item as chrome.tabs.Tab)).toThrow();
 })
 
+/**
+ * Create a SwitchTabEvent from the information passed by the browser.
+ */
 test('Create SwitchTabEvent', () => {
     let evt : SwitchTabEvent = factory.createSwitchTabEvent({tabId : 105} as chrome.tabs.TabActiveInfo, item as chrome.tabs.Tab);
     expect(evt).toMatchObject({_tabID : item.id, _windowID : item.windowId, _newTabID : 105});

--- a/application/BrowserExtension/src/__tests__/Listeners/Tab/TabListener.test.ts
+++ b/application/BrowserExtension/src/__tests__/Listeners/Tab/TabListener.test.ts
@@ -78,6 +78,17 @@ test("Capture OpenTabEvent", done => {
     });
 })
 
+//ensure that the callback is not triggered if no tabID has been created
+test("OpenTabEvent no TabID", done => {
+    listener.start();
+    expect(mockCallback).toHaveBeenCalledTimes(0);
+    chrome.tabs.onCreated.trigger({windowId : 3});
+    wait().then(() => {
+        expect(mockCallback).toHaveBeenCalledTimes(0);
+        done();
+    });
+})
+
 //capture an CloseTabEvent and check its fields
 test("Capture CloseTabEvent", done => {
     listener.start();

--- a/application/BrowserExtension/src/__tests__/PostHTTPInterface.test.ts
+++ b/application/BrowserExtension/src/__tests__/PostHTTPInterface.test.ts
@@ -22,6 +22,7 @@ beforeEach(() => {
     comm = new PostHTTPInterface("http://localhost:60024");
 })
 
+//confirm that connection is established when receiving a valid answer
 test("Establish connection", done => {
     class Response {
         json() {
@@ -36,6 +37,7 @@ test("Establish connection", done => {
     }).catch((e) => fail(e));
 })
 
+//confirm that connection is not established when receiving an invalid answer
 test("Establish connection (wrong response)", done => {
     class Response {
         json() {
@@ -47,6 +49,7 @@ test("Establish connection (wrong response)", done => {
     comm.establishConnection().then(() => fail(invalidAppString)).catch(() => done());
 })
 
+//confirm that config is correctly received
 test("Request config", done => {
     class Response {
         json() {
@@ -58,6 +61,7 @@ test("Request config", done => {
     comm.requestConfig().then((config) => {expect(config).toBe("Somevalue"); done();});
 })
 
+//confirm that requestConfig rejects when receiving an invalid answer
 test("Request config (wrong response)", done => {
     class Response {
         json() {
@@ -69,6 +73,7 @@ test("Request config (wrong response)", done => {
     comm.requestConfig().then(() => fail(invalidAppString)).catch(() => done());
 })
 
+//confirm that waitForStart is resolved when receiving the expected answer
 test("Wait for start", done => {
     class Response {
         json() {
@@ -80,6 +85,7 @@ test("Wait for start", done => {
     comm.waitForStart().then(() => done());
 })
 
+//confirm that waitForStart is rejected when receiving an unexpected answer
 test("Wait for start (invalid response)", done => {
     class Response {
         json() {
@@ -91,6 +97,7 @@ test("Wait for start (invalid response)", done => {
     comm.waitForStart().then(() => fail("Should only resolve when recieiving Start-command")).catch(() => done());
 })
 
+//confirm that the onStopCallback passed to the PostHTTPInterface is invoked when receiving a stop-message
 test("OnStopListener", done => {
     class Response {
         private running : boolean = false;
@@ -117,6 +124,7 @@ test("OnStopListener", done => {
     });
 })
 
+//confirm that sending data works
 test("Send data", done => {
     class Response {
         json() {
@@ -128,11 +136,17 @@ test("Send data", done => {
     mySample._buttonHref = "https://sample.com/redirect";
     let fetch = jest.fn((...args : any[]) => new Promise((resolve) => resolve(new Response)));
     globalAny.fetch = fetch;
-    comm.sendData(new ButtonClickEvent(mySample._tabID, mySample._windowID, mySample._buttonTitle,mySample._url).serialize()).then(() => {
+    let data = new ButtonClickEvent(mySample._tabID, mySample._windowID, mySample._buttonTitle,mySample._url).serialize();
+    comm.sendData(data).then(() => {
+        expect(fetch).toHaveBeenCalledWith("http://localhost:60024", {
+            method : "POST",
+            body: `{"request" : "sendData", "data" : ${data}}`,
+        });
         done();
     })
 })
 
+//confirm that sending data also throws when receiving an invalid answer
 test("Send data (invalid answer)", done => {
     class Response {
         json() {
@@ -149,6 +163,7 @@ test("Send data (invalid answer)", done => {
     }).catch(() => done());
 })
 
+//confirm that sendData will pass through Stop-commands
 test("Send data (stop answer)", done => {
     class Response {
         json() {
@@ -171,6 +186,7 @@ test("Send data (stop answer)", done => {
     });
 })
 
+//test if PostHTTPInterface will create a port-entry in browser storage when the extension is installed.
 test("Set port", () => {
     expect(chrome.storage.local.set.calledOnceWith({"port": "No Port Set!"})).toBeFalsy();
     chrome.runtime.onInstalled.trigger({reason : "install"});

--- a/application/BrowserExtension/src/__tests__/PostHTTPInterface.test.ts
+++ b/application/BrowserExtension/src/__tests__/PostHTTPInterface.test.ts
@@ -1,0 +1,37 @@
+import { chrome, resetChrome } from '../__mock__/chrome_mock'
+const globalAny:any = global;
+globalAny.chrome = chrome
+import PostHTTPInterface from '../ApplicationInterface/PostHTTPInterface'
+
+let comm : PostHTTPInterface;
+
+
+beforeAll(() => {
+    jest.resetAllMocks();
+    comm = new PostHTTPInterface("http://localhost:60024");
+})
+
+test("Establish connection", done => {
+    class Response {
+        json() {
+            return {application: "MORR", response: "Ok"};
+        } 
+    }
+    let fetch = jest.fn((...args : any[]) => new Promise((resolve) => resolve(new Response)));
+    globalAny.fetch = fetch;
+    comm.establishConnection().then(() => {
+        expect(fetch.mock.calls[0][0]).toEqual("http://localhost:60024"); //check that interface contacted correct address
+        done();
+    }).catch((e) => fail(e));
+})
+
+test("Establish connection (wrong response)", done => {
+    class Response {
+        json() {
+            return {application: "Internet Explorer", response: "Ok"}; //wrong application identifier
+        } 
+    }
+    let fetch = (...args : any[]) => new Promise((resolve) => resolve(new Response));
+    globalAny.fetch = fetch;
+    comm.establishConnection().then(() => fail("Connection should not be accepted for invalid application")).catch(() => done());
+})

--- a/application/BrowserExtension/src/__tests__/PostHTTPInterface.test.ts
+++ b/application/BrowserExtension/src/__tests__/PostHTTPInterface.test.ts
@@ -1,5 +1,4 @@
 import { chrome, resetChrome } from '../__mock__/chrome_mock'
-//import chrome from 'sinon-chrome'
 const globalAny:any = global;
 globalAny.chrome = chrome
 import PostHTTPInterface from '../ApplicationInterface/PostHTTPInterface'
@@ -17,6 +16,9 @@ const sample : any = {_issuingModule : 0, _windowID : 3, _tabID : 7,  _url : new
 
 beforeAll(() => {
     jest.resetAllMocks();
+})
+
+beforeEach(() => {
     comm = new PostHTTPInterface("http://localhost:60024");
 })
 

--- a/application/BrowserExtension/src/__tests__/PostHTTPInterface.test.ts
+++ b/application/BrowserExtension/src/__tests__/PostHTTPInterface.test.ts
@@ -1,10 +1,19 @@
 import { chrome, resetChrome } from '../__mock__/chrome_mock'
+//import chrome from 'sinon-chrome'
 const globalAny:any = global;
 globalAny.chrome = chrome
 import PostHTTPInterface from '../ApplicationInterface/PostHTTPInterface'
+import { ButtonClickEvent } from '../Listeners/DOM/DOMEvents';
+
+//Suppress console output for tests
+let log = () => undefined;
+globalAny.console.log = log;
+globalAny.console.error = log;
 
 let comm : PostHTTPInterface;
-
+const invalidAppString : string = "Connection should not be accepted for invalid application";
+const WAITTIME = 30; //how long to wait before counting callback-invocations
+const sample : any = {_issuingModule : 0, _windowID : 3, _tabID : 7,  _url : new URL("http://sample.com")};
 
 beforeAll(() => {
     jest.resetAllMocks();
@@ -33,5 +42,139 @@ test("Establish connection (wrong response)", done => {
     }
     let fetch = (...args : any[]) => new Promise((resolve) => resolve(new Response));
     globalAny.fetch = fetch;
-    comm.establishConnection().then(() => fail("Connection should not be accepted for invalid application")).catch(() => done());
+    comm.establishConnection().then(() => fail(invalidAppString)).catch(() => done());
+})
+
+test("Request config", done => {
+    class Response {
+        json() {
+            return {application: "MORR", config: "Somevalue"}; //wrong application identifier
+        } 
+    }
+    let fetch = (...args : any[]) => new Promise((resolve) => resolve(new Response));
+    globalAny.fetch = fetch;
+    comm.requestConfig().then((config) => {expect(config).toBe("Somevalue"); done();});
+})
+
+test("Request config (wrong response)", done => {
+    class Response {
+        json() {
+            return {application: "CMD.exe", config: "Somevalue"}; //wrong application identifier
+        } 
+    }
+    let fetch = (...args : any[]) => new Promise((resolve) => resolve(new Response));
+    globalAny.fetch = fetch;
+    comm.requestConfig().then(() => fail(invalidAppString)).catch(() => done());
+})
+
+test("Wait for start", done => {
+    class Response {
+        json() {
+            return {application: "MORR", response: "Start"};
+        } 
+    }
+    let fetch = jest.fn((...args : any[]) => new Promise((resolve) => resolve(new Response)));
+    globalAny.fetch = fetch;
+    comm.waitForStart().then(() => done());
+})
+
+test("Wait for start (invalid response)", done => {
+    class Response {
+        json() {
+            return {application: "MORR", response: "Ok"};
+        } 
+    }
+    let fetch = jest.fn((...args : any[]) => new Promise((resolve) => resolve(new Response)));
+    globalAny.fetch = fetch;
+    comm.waitForStart().then(() => fail("Should only resolve when recieiving Start-command")).catch(() => done());
+})
+
+test("OnStopListener", done => {
+    class Response {
+        private running : boolean = false;
+        json() {
+            console.log("Running is now " + this.running);
+            this.running = !this.running;
+            if (this.running)
+                return {application: "MORR", response: "Start"};
+            else
+                return {application: "MORR", response: "Stop"};
+        }
+    }
+    let resp = new Response();
+    let fetch = jest.fn((...args : any[]) => new Promise((resolve) => resolve(resp)));
+    globalAny.fetch = fetch;
+    let callback = jest.fn();
+    comm.addOnStopListener(callback);
+    comm.waitForStart().then(() => {
+        setTimeout(() => {
+            expect(callback).toHaveBeenCalledTimes(1);
+            done();
+        }, WAITTIME);
+
+    });
+})
+
+test("Send data", done => {
+    class Response {
+        json() {
+            return {application: "MORR", response: "Ok"};
+        } 
+    }
+    const mySample = {...sample};
+    mySample._buttonTitle = "Click Me!";
+    mySample._buttonHref = "https://sample.com/redirect";
+    let fetch = jest.fn((...args : any[]) => new Promise((resolve) => resolve(new Response)));
+    globalAny.fetch = fetch;
+    comm.sendData(new ButtonClickEvent(mySample._tabID, mySample._windowID, mySample._buttonTitle,mySample._url).serialize()).then(() => {
+        done();
+    })
+})
+
+test("Send data (invalid answer)", done => {
+    class Response {
+        json() {
+            return {application: "cmd.exe", response: "Ok"};
+        } 
+    }
+    const mySample = {...sample};
+    mySample._buttonTitle = "Click Me!";
+    mySample._buttonHref = "https://sample.com/redirect";
+    let fetch = jest.fn((...args : any[]) => new Promise((resolve) => resolve(new Response)));
+    globalAny.fetch = fetch;
+    comm.sendData(new ButtonClickEvent(mySample._tabID, mySample._windowID, mySample._buttonTitle,mySample._url).serialize()).then(() => {
+        fail(() => invalidAppString);
+    }).catch(() => done());
+})
+
+test("Send data (stop answer)", done => {
+    class Response {
+        json() {
+            return {application: "MORR", response: "Stop"};
+        } 
+    }
+    const mySample = {...sample};
+    mySample._buttonTitle = "Click Me!";
+    mySample._buttonHref = "https://sample.com/redirect";
+    let fetch = jest.fn((...args : any[]) => new Promise((resolve) => resolve(new Response)));
+    globalAny.fetch = fetch;
+    let callback = jest.fn();
+    comm.addOnStopListener(callback);
+    comm.sendData(new ButtonClickEvent(mySample._tabID, mySample._windowID, mySample._buttonTitle,mySample._url).serialize()).then((resp) => {
+        expect(resp).toEqual("Stop");
+        setTimeout(() => {
+            expect(callback).toBeCalledTimes(1);
+            done();
+        }, WAITTIME);
+    });
+})
+
+test("Set port", () => {
+    expect(chrome.storage.local.set.calledOnceWith({"port": "No Port Set!"})).toBeFalsy();
+    chrome.runtime.onInstalled.trigger({reason : "install"});
+    expect(chrome.storage.local.set.calledOnceWith({"port": "No Port Set!"})).toBeTruthy();
+    test.only("Set port", () => {
+        chrome.runtime.onInstalled.trigger({reason : "someelse"});
+        expect(chrome.storage.local.set.calledTwice).toBeFalsy();
+    })
 })

--- a/application/BrowserExtension/src/__tests__/Shared/BrowserEvent.tests.ts
+++ b/application/BrowserExtension/src/__tests__/Shared/BrowserEvent.tests.ts
@@ -37,3 +37,9 @@ test("Event serialization", () => {
     expect(evt.serialize()).toBe("{\"_issuingModule\":0,\"_type\":\"Generic\",\"_timeStamp\":"
                                 + JSON.stringify(evt.timeStamp) + ",\"_tabID\":7,\"_windowID\":3,\"_url\":\"http://kit.edu/\"}");
 })
+
+test("Event serialization (no underscore)", () => {
+    let evt : BrowserEvent = new BrowserEvent(testData._type, testData._tabID, testData._windowID, testData._url.toString());
+    expect(evt.serialize(true)).toBe("{\"issuingModule\":0,\"type\":\"Generic\",\"timeStamp\":"
+                                + JSON.stringify(evt.timeStamp) + ",\"tabID\":7,\"windowID\":3,\"url\":\"http://kit.edu/\"}");
+})

--- a/application/BrowserExtension/src/background.ts
+++ b/application/BrowserExtension/src/background.ts
@@ -12,7 +12,7 @@ enum ExtensionState {
 /**
  * The "main" class of the webextension
  */
-class BackgroundScript {
+export default class BackgroundScript {
     /**
      * ListenerManager controlled by background script
      */


### PR DESCRIPTION
This PR adds the remaining tests to the webextension. The tests are by no means complete in terms of testcoverage. One reason is some functionality relying too heavily on the browser-environment (e. g. DOMEventRecorder), also some branches are only present to handle browser-specific quirks by logging a message and then returning.

**Note:** As this PR adds addtional dependencies, you most likely need to run `npm install` first for tests to be successful..

### Testcoverage:

File                             |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
---------------------------------|----------|----------|----------|----------|-------------------|
All files                        |    85.16 |    67.92 |    85.03 |    85.79 |                   |
 src                             |    83.93 |    70.83 |     62.5 |    86.24 |                   |
  ListenerManager.ts             |       85 |      100 |     62.5 |      100 |                   |
  background.ts                  |     83.7 |       65 |     62.5 |     83.7 |... 51,164,194,195 |
 src/ApplicationInterface        |    87.14 |    72.97 |    93.94 |    87.14 |                   |
  PostHTTPInterface.ts           |    87.14 |    72.97 |    93.94 |    87.14 |... 39,40,41,42,45 |
 src/Listeners/DOM               |    94.02 |    70.83 |    96.77 |    94.02 |                   |
  DOMEvents.ts                   |      100 |    77.78 |      100 |      100 |    51,117,181,231 |
  DOMListener.ts                 |    84.78 |    66.67 |       90 |    84.78 |... 89,105,108,109 |
 src/Listeners/DOM/ContentScript |    61.06 |    52.22 |    54.55 |    61.61 |                   |
  DOMEventFactory.ts             |    76.67 |    57.32 |    92.31 |    77.53 |... 77,179,185,196 |
  DOMEventRecorder.ts            |        0 |        0 |        0 |        0 |... 73,74,75,79,81 |
 src/Listeners/Download          |      100 |      100 |      100 |      100 |                   |
  DownloadEventFactory.ts        |      100 |      100 |      100 |      100 |                   |
  DownloadEvents.ts              |      100 |      100 |      100 |      100 |                   |
  DownloadListener.ts            |      100 |      100 |      100 |      100 |                   |
 src/Listeners/Tab               |    96.55 |    95.45 |      100 |    96.55 |                   |
  TabEventFactory.ts             |      100 |      100 |      100 |      100 |                   |
  TabEvents.ts                   |      100 |      100 |      100 |      100 |                   |
  TabListener.ts                 |    94.74 |    91.67 |      100 |    94.74 |             82,83 |
 src/Shared                      |    97.56 |    84.62 |      100 |    97.56 |                   |
  SharedDeclarations.ts          |    97.56 |    84.62 |      100 |    97.56 |                90 |

Closes #135 