### PR TITLE
Add Webbrowser module unittests

### DIFF
--- a/application/Modules/WebBrowser/WebBrowserModule.cs
+++ b/application/Modules/WebBrowser/WebBrowserModule.cs
@@ -84,5 +84,16 @@ namespace MORR.Modules.WebBrowser
                 producers.ForEach(producer => producer.Close());
             }
         }
+
+        //revert back to unitialized state, only needed for (unit-)testing
+        public void Reset()
+        {
+            if (listener != null)
+            {
+                listener.StopListening();
+                listener = null;
+            }
+            producers = null;
+        }
     }
 }

--- a/application/Modules/WebBrowser/WebBrowserModule.cs
+++ b/application/Modules/WebBrowser/WebBrowserModule.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Runtime.CompilerServices;
 using MORR.Modules.WebBrowser.Producers;
 using MORR.Shared.Modules;
 using MORR.Shared.Utility;
 
+[assembly: InternalsVisibleTo("WebBrowserTest")]
 namespace MORR.Modules.WebBrowser
 {
     /// <summary>
@@ -86,7 +88,7 @@ namespace MORR.Modules.WebBrowser
         }
 
         //revert back to unitialized state, only needed for (unit-)testing
-        public void Reset()
+        internal void Reset()
         {
             if (listener != null)
             {

--- a/application/Modules/WebBrowser/WebExtensionListener.cs
+++ b/application/Modules/WebBrowser/WebExtensionListener.cs
@@ -243,7 +243,7 @@ namespace MORR.Modules.WebBrowser
                     case WebBrowserRequestType.CONFIG:
                         AnswerRequest(context.Response,
                                       new WebBrowserResponse(ResponseStrings.POSITIVERESPONSE,
-                                                             "undefined")); //TODO: retrieve and send config
+                                                             "undefined")); //only stub-implementation in case it should find usage later
                         break;
                     case WebBrowserRequestType.START:
                         if (recordingActive)
@@ -257,15 +257,23 @@ namespace MORR.Modules.WebBrowser
 
                         break;
                     case WebBrowserRequestType.SENDDATA:
-                        if (request.Data != null && DeserializeEventAndBroadcast(request))
+                        if (!recordingActive)
                         {
-                            AnswerRequest(context.Response, new WebBrowserResponse(ResponseStrings.POSITIVERESPONSE));
+                            //this code is only reached if the recording has been stopped in MORR,
+                            //but the webextension has not yet been informed.
+                            AnswerRequest(context.Response, new WebBrowserResponse(ResponseStrings.STOPRESPONSE));
                         }
                         else
                         {
-                            AnswerInvalid(context.Response);
+                            if (request.Data != null && DeserializeEventAndBroadcast(request))
+                            {
+                                AnswerRequest(context.Response, new WebBrowserResponse(ResponseStrings.POSITIVERESPONSE));
+                            }
+                            else
+                            {
+                                AnswerInvalid(context.Response);
+                            }
                         }
-
                         break;
                     case WebBrowserRequestType.WAITSTOP:
                         if (!recordingActive)

--- a/application/Modules/WebBrowserTest/WebBrowserEventTest.cs
+++ b/application/Modules/WebBrowserTest/WebBrowserEventTest.cs
@@ -9,7 +9,7 @@ namespace WebBrowserTest
     [TestClass]
     public class WebBrowserEventTest
     {
-        private readonly DateTime commonDateTime = new DateTime(2020, 03, 05, 10, 10, 51, 123);
+        private readonly DateTime commonDateTime = DateTime.Parse("2020-03-05T10:10:51.1230000+01:00");
         private const int commonTabId = 5;
         private const string commonText = "SomeText";
         private readonly Uri commonUrl = new Uri("https://sample.com/");

--- a/application/Modules/WebBrowserTest/WebBrowserEventTest.cs
+++ b/application/Modules/WebBrowserTest/WebBrowserEventTest.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MORR.Modules.WebBrowser.Events;
+
+namespace WebBrowserTest
+{
+    [TestClass]
+    public class WebBrowserEventTest
+    {
+        private readonly DateTime commonDateTime = new DateTime(2020, 03, 05, 10, 10, 51, 123);
+        private const int commonTabId = 5;
+        private const string commonText = "SomeText";
+        private readonly Uri commonUrl = new Uri("https://sample.com/");
+        private const string serializedEvent = "{\"buttonTitle\":\"SomeText\",\"buttonHref\":\"https://sample.com/redirect\"," +
+            "\"tabID\":5,\"url\":\"https://sample.com\"," +
+            "\"timeStamp\":\"2020-03-05T10:10:51.1230000+01:00\",\"fileURL\":\"https://sample.com/download\",\"mimeType\":\"JSON\"," +
+            "\"target\":\"SomeLabel\",\"newTabID\":7,\"text\":\"SomeInput\",\"textSelection\":\"SomeSelection\"}";
+
+        //test if ButtonClick attributes are correctly deserialized
+        [TestMethod]
+        public void DeserializeButtonClickEvent()
+        {
+            /* GIVEN */
+            string eventJson = "{\"buttonTitle\":\"SomeText\",\"buttonHref\":\"https://sample.com/redirect\",\"tabID\":5,\"url\":\"https://sample.com\",\"timeStamp\":\"2020-03-05T10:10:51.1230000+01:00\"}";
+            var deserialized = new ButtonClickEvent();
+
+            /* WHEN */
+            deserialized.Deserialize(eventJson);
+
+            /* THEN */
+            TestCommonAttributes(deserialized);
+            Assert.AreEqual(commonText, deserialized.Button);
+            Assert.AreEqual("https://sample.com/redirect", deserialized.Href);
+        }
+
+        //test if CloseTabEvent attributes are correctly deserialized
+        [TestMethod]
+        public void DeserializeCloseTabEvent()
+        {
+            /* GIVEN */
+            var deserialized = new CloseTabEvent();
+
+            /* WHEN */
+            deserialized.Deserialize(serializedEvent);
+
+            /* THEN */
+            TestCommonAttributes(deserialized);
+        }
+
+        //test if FileDownloadEvent attributes are correctly deserialized
+        [TestMethod]
+        public void DeserializeFileDownloadEvent()
+        {
+            /* GIVEN */
+            var deserialized = new FileDownloadEvent();
+
+            /* WHEN */
+            deserialized.Deserialize(serializedEvent);
+
+            /* THEN */
+            TestCommonAttributes(deserialized);
+            Assert.AreEqual(new Uri("https://sample.com/download"), deserialized.FileURL);
+            Assert.AreEqual("JSON", deserialized.MIMEType);
+        }
+
+        //test if HoverEvent attributes are correctly deserialized
+        [TestMethod]
+        public void DeserializeHoverEvent()
+        {
+            /* GIVEN */
+            var deserialized = new HoverEvent();
+
+            /* WHEN */
+            deserialized.Deserialize(serializedEvent);
+
+            /* THEN */
+            TestCommonAttributes(deserialized);
+            Assert.AreEqual("SomeLabel", deserialized.HoveredElement);
+        }
+
+        //test if NavigationEvent attributes are correctly deserialized
+        [TestMethod]
+        public void DeserializeNavigationEvent()
+        {
+            /* GIVEN */
+            var deserialized = new NavigationEvent();
+
+            /* WHEN */
+            deserialized.Deserialize(serializedEvent);
+
+            /* THEN */
+            TestCommonAttributes(deserialized);
+        }
+
+        //test if OpenTabEvent attributes are correctly deserialized
+        [TestMethod]
+        public void DeserializeOpenTabEvent()
+        {
+            /* GIVEN */
+            var deserialized = new OpenTabEvent();
+
+            /* WHEN */
+            deserialized.Deserialize(serializedEvent);
+
+            /* THEN */
+            TestCommonAttributes(deserialized);
+        }
+
+        //test if SwitchTabEvent attributes are correctly deserialized
+        [TestMethod]
+        public void DeserializeSwitchTabEvent()
+        {
+            /* GIVEN */
+            var deserialized = new SwitchTabEvent();
+
+            /* WHEN */
+            deserialized.Deserialize(serializedEvent);
+
+            /* THEN */
+            TestCommonAttributes(deserialized);
+            Assert.AreEqual(7, deserialized.NewTabID);
+        }
+
+        //test if TextInputEvent attributes are correctly deserialized
+        [TestMethod]
+        public void DeserializeTextInputEvent()
+        {
+            /* GIVEN */
+            var deserialized = new TextInputEvent();
+
+            /* WHEN */
+            deserialized.Deserialize(serializedEvent);
+
+            /* THEN */
+            TestCommonAttributes(deserialized);
+            Assert.AreEqual(deserialized.InputtedText, "SomeInput");
+            Assert.AreEqual("SomeLabel", deserialized.Textbox);
+        }
+
+        //test if TextSelectionEvent attributes are correctly deserialized
+        [TestMethod]
+        public void DeserializeTextSelectionEvent()
+        {
+            /* GIVEN */
+            var deserialized = new TextSelectionEvent();
+
+            /* WHEN */
+            deserialized.Deserialize(serializedEvent);
+
+            /* THEN */
+            TestCommonAttributes(deserialized);
+            Assert.AreEqual("SomeSelection", deserialized.SelectedText);
+        }
+
+        private void TestCommonAttributes(WebBrowserEvent deserialized)
+        {
+            Assert.AreEqual(commonUrl, deserialized.CurrentURL);
+            Assert.AreEqual(commonDateTime, deserialized.Timestamp);
+            Assert.AreEqual(commonTabId, deserialized.TabID);
+        }
+    }
+}

--- a/application/Modules/WebBrowserTest/WebBrowserModuleTest.cs
+++ b/application/Modules/WebBrowserTest/WebBrowserModuleTest.cs
@@ -332,9 +332,6 @@ namespace WebBrowserTest
         {
             var requestUri = new Uri("http://localhost:" + config.UrlSuffix);
             var request = new HttpRequestMessage(HttpMethod.Post, "relativeAddress");
-            /*request.Content = new StringContent("{\"name\":\"John Doe\",\"age\":33}",
-                                                Encoding.UTF8,
-                                                "application/json");//CONTENT-TYPE header */
             request.Content = new StringContent(JsonSerializer.Serialize(data),
                                                 Encoding.UTF8,
                                                 "application/json"); //CONTENT-TYPE header

--- a/application/Modules/WebBrowserTest/WebBrowserModuleTest.cs
+++ b/application/Modules/WebBrowserTest/WebBrowserModuleTest.cs
@@ -1,6 +1,12 @@
+using System;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.Diagnostics;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using MORR.Modules.WebBrowser;
@@ -23,7 +29,19 @@ namespace WebBrowserTest
         private Mock<TextInputEventProducer> textInputEventProducer;
         private Mock<TextSelectionEventProducer> textSelectionEventProducer;
         private WebBrowserModule webBrowserModule;
+        private static WebBrowserModuleConfiguration config = new TestWebBrowserModuleConfiguration();
+        private static HttpClient testClient;
 
+        [ClassInitialize]
+        public static void InitializeClass(TestContext context)
+        {
+            InitializeHTTPClient(config.UrlSuffix);
+        }
+        [TestCleanup]
+        public void AfterTest()
+        {
+            webBrowserModule.Reset();
+        }
         [TestInitialize]
         public void BeforeTest()
         {
@@ -84,12 +102,53 @@ namespace WebBrowserTest
             Assert.IsFalse(webBrowserModule.IsActive);
         }
 
+        [TestMethod]
+        public async Task SendConnectionRequest()
+        {
+            webBrowserModule.Initialize(true);
+            webBrowserModule.IsActive = true;
+            var result = await SendHTTPMessage("{\"Request\":\"Connect\"}");
+
+            Assert.AreEqual("Ok", result.GetProperty("response").GetString());
+        }
+
+        private static JsonElement GetJsonFromString(string data)
+        {
+            return JsonDocument.Parse(data).RootElement;
+        }
+
         private class TestWebBrowserModuleConfiguration : WebBrowserModuleConfiguration
         {
             public TestWebBrowserModuleConfiguration()
             {
                 UrlSuffix = "60024/";
             }
+        }
+
+        private static void InitializeHTTPClient(string UrlSuffix)
+        {
+            testClient = new HttpClient();
+            Uri requestUri = new Uri("http://localhost:" + UrlSuffix);
+            testClient.BaseAddress = requestUri;
+            testClient.DefaultRequestHeaders
+                  .Accept
+                  .Add(new MediaTypeWithQualityHeaderValue("application/json"));//ACCEPT header
+        }
+
+        private async Task<JsonElement> SendHTTPMessage(string data)
+        {
+            Uri requestUri = new Uri("http://localhost:" + config.UrlSuffix);
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "relativeAddress");
+            /*request.Content = new StringContent("{\"name\":\"John Doe\",\"age\":33}",
+                                                Encoding.UTF8,
+                                                "application/json");//CONTENT-TYPE header */
+            request.Content = new StringContent(data,
+                                                 Encoding.UTF8,
+                                                "application/json");//CONTENT-TYPE header
+
+            var response = await testClient.PostAsync(requestUri, request.Content);
+            string result = response.Content.ReadAsStringAsync().Result;
+            return GetJsonFromString(result);
         }
     }
 }

--- a/application/Modules/WebBrowserTest/WebBrowserModuleTest.cs
+++ b/application/Modules/WebBrowserTest/WebBrowserModuleTest.cs
@@ -34,6 +34,15 @@ namespace WebBrowserTest
         private static HttpClient testClient;
         private JsonElement? lastJson = null;
 
+        private struct StringConstants
+        {
+            public const string appIdentifier = "MORR";
+            public const string okString = "Ok";
+            public const string startString = "Start";
+            public const string stopString = "Stop";
+            public const string invalidString = "Invalid Request";
+        }
+
         [ClassInitialize]
         public static void InitializeClass(TestContext context)
         {
@@ -118,8 +127,8 @@ namespace WebBrowserTest
             var result = await SendHTTPMessage(new { Request = "Connect" });
 
             /* THEN */
-            Assert.AreEqual("Ok", result.GetProperty("response").GetString());
-            Assert.AreEqual("MORR", result.GetProperty("application").GetString());
+            Assert.AreEqual(StringConstants.okString, result.GetProperty("response").GetString());
+            Assert.AreEqual(StringConstants.appIdentifier, result.GetProperty("application").GetString());
         }
 
         [TestMethod]
@@ -134,8 +143,8 @@ namespace WebBrowserTest
             var result = await SendHTTPMessage(new { Request = "HelloItsMe" });
 
             /* THEN */
-            Assert.AreEqual("Invalid Request", result.GetProperty("response").GetString());
-            Assert.AreEqual("MORR", result.GetProperty("application").GetString());
+            Assert.AreEqual(StringConstants.invalidString, result.GetProperty("response").GetString());
+            Assert.AreEqual(StringConstants.appIdentifier, result.GetProperty("application").GetString());
         }
 
         [TestMethod]
@@ -150,8 +159,8 @@ namespace WebBrowserTest
             var result = await SendHTTPMessage(new { Request = "Config" });
 
             /* THEN */
-            Assert.AreEqual("Ok", result.GetProperty("response").GetString());
-            Assert.AreEqual("MORR", result.GetProperty("application").GetString());
+            Assert.AreEqual(StringConstants.okString, result.GetProperty("response").GetString());
+            Assert.AreEqual(StringConstants.appIdentifier, result.GetProperty("application").GetString());
             Assert.IsTrue(result.TryGetProperty("config", out var config));
             //Sending a config from MORR to the webextension is only added as a stub (unused),
             //so we only verify that any config string is sent.
@@ -182,8 +191,8 @@ namespace WebBrowserTest
             });
 
             /* THEN */
-            Assert.AreEqual("Ok", result.GetProperty("response").GetString());
-            Assert.AreEqual("MORR", result.GetProperty("application").GetString());
+            Assert.AreEqual(StringConstants.okString, result.GetProperty("response").GetString());
+            Assert.AreEqual(StringConstants.appIdentifier, result.GetProperty("application").GetString());
 
             buttonClickEventProducer.Verify(mock => mock.Notify(It.IsAny<JsonElement>()), Times.Once);
             Assert.IsNotNull(lastJson);
@@ -198,6 +207,33 @@ namespace WebBrowserTest
         }
 
         [TestMethod]
+        //verify that senddata-request is correctly handled of no recording is active
+        public async Task SendDataNotRecording()
+        {
+            // Preconditions
+            webBrowserModule.Initialize(true);
+            var data = new
+            {
+                buttonTitle = "SomeText",
+                buttonHref = "https://sample.com/redirect",
+                tabID = 5,
+                url = "https://sample.com",
+                timeStamp = new DateTime(2015, 5, 6, 7, 8, 9, 512),
+                type = "BUTTONCLICK"
+            };
+            /* WHEN */
+            var result = await SendHTTPMessage(new
+            {
+                Request = "SendData",
+                Data = data
+            });
+
+            /* THEN */
+            Assert.AreEqual(StringConstants.stopString, result.GetProperty("response").GetString());
+            Assert.AreEqual(StringConstants.appIdentifier, result.GetProperty("application").GetString());
+        }
+
+        [TestMethod]
         //verify that start-request is correctly answered
         public async Task IssueStart()
         {
@@ -209,8 +245,8 @@ namespace WebBrowserTest
             var result = await SendHTTPMessage(new { Request = "Start" });
 
             /* THEN */
-            Assert.AreEqual("Start", result.GetProperty("response").GetString());
-            Assert.AreEqual("MORR", result.GetProperty("application").GetString());
+            Assert.AreEqual(StringConstants.startString, result.GetProperty("response").GetString());
+            Assert.AreEqual(StringConstants.appIdentifier, result.GetProperty("application").GetString());
         }
 
 
@@ -247,8 +283,8 @@ namespace WebBrowserTest
             var result = await SendHTTPMessage(new { Request = "WAITSTOP" });
 
             /* THEN */
-            Assert.AreEqual("Stop", result.GetProperty("response").GetString());
-            Assert.AreEqual("MORR", result.GetProperty("application").GetString());
+            Assert.AreEqual(StringConstants.stopString, result.GetProperty("response").GetString());
+            Assert.AreEqual(StringConstants.appIdentifier, result.GetProperty("application").GetString());
         }
 
         [TestMethod]


### PR DESCRIPTION
Adds unit tests which test if the WebbrowserModule behaves correctly when the possible requests are sent to it.

They are a bit slow since two of them wait for two seconds each (as they test if a request is NOT answered, which can hardly be verified without waiting).

I only tested sending events to the ButtonClickEventProducer, since all producers currently share an implementation. Also, the mocked producers by default somehow all register for BUTTONCLICK events, meaning using any other producer would require additional setup first.

The tests only go as far as checking of **Notify** is called on the producer, as i wasn't competent enough to retrieve events from the queue in the test (there is also nothing interesting going on inbetween).

Closes #140 