### PR TITLE
Add CryptoHelper and add hashed user name to session name

### DIFF
--- a/application/Core/MORR/Session/Crypto/CryptoHelper.cs
+++ b/application/Core/MORR/Session/Crypto/CryptoHelper.cs
@@ -1,0 +1,28 @@
+﻿using System.Text;
+using System.Security.Cryptography;
+
+namespace MORR.Core.Session.Crypto
+{
+    public static class CryptoHelper
+    {
+        /// <summary>
+        /// Generates a hash of the provided string using the SHA256 algorithm.
+        /// </summary>
+        /// <param name="rawData">The string to be hashed.</param>
+        /// <returns>The hashed version of the rawData string.</returns>
+        public static string GenerateHash(string rawData)
+        {
+            using SHA256 hash = SHA256.Create();
+            byte[] hashedBytes = hash.ComputeHash(Encoding.UTF8.GetBytes(rawData));
+
+            const string convertFormat = "x2";
+            StringBuilder builder = new StringBuilder();
+            for (var index = 0; index < hashedBytes.Length; index++)
+            {
+                builder.Append(hashedBytes[index].ToString(convertFormat));
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/application/Core/MORR/Session/SessionManager.cs
+++ b/application/Core/MORR/Session/SessionManager.cs
@@ -7,6 +7,7 @@ using MORR.Core.Configuration;
 using MORR.Core.Data.Transcoding;
 using MORR.Core.Modules;
 using MORR.Core.Session.Exceptions;
+using MORR.Core.Session.Crypto;
 using MORR.Shared.Hook;
 using MORR.Shared.Utility;
 
@@ -15,6 +16,7 @@ namespace MORR.Core.Session
     public class SessionManager : ISessionManager
     {
         private const string dateFormat = "yyyy-MM-ddTHH-mm-ss";
+        private const string fileDivider = "--";
         private IEnumerable<IEncoder> encoders = new IEncoder[0];
         private IEnumerable<IDecoder> decoders = new IDecoder[0];
         private readonly IModuleManager moduleManager;
@@ -59,9 +61,12 @@ namespace MORR.Core.Session
 
         private DirectoryPath CreateNewRecordingDirectory()
         {
-            var timeNow = DateTime.Now;
-            var sessionId = Guid.NewGuid();
-            var directory = Path.Combine(Configuration.RecordingDirectory.ToString(), timeNow.ToString(dateFormat) + "-" + sessionId.ToString());
+            var timeNow = DateTime.Now.ToString(dateFormat);
+            var dir = Configuration.RecordingDirectory.ToString();
+            var sessionId = Guid.NewGuid().ToString();
+            var username = CryptoHelper.GenerateHash(Environment.UserName);
+
+            var directory = Path.Combine(dir, timeNow + fileDivider + username + fileDivider + sessionId);
             Directory.CreateDirectory(directory);
             return new DirectoryPath(directory);
         }


### PR DESCRIPTION
This PR introduces the requested changes to the session folder name.

The new folder name now consists of three parts:

- `___DATE___`
- `___HASHED_USERNAME___`
- `___SESSION_ID___`

using the following scheme:

`___DATE___--___HASHED_USERNAME___--___SESSION_ID___`

closes #145 