### PR TITLE
Improve WebBrowserModule

### DIFF
--- a/application/Modules/WebBrowser/WebBrowserModule.cs
+++ b/application/Modules/WebBrowser/WebBrowserModule.cs
@@ -66,19 +66,18 @@ namespace MORR.Modules.WebBrowser
                 switchTabEventProducer, textInputEventProducer, textSelectionEventProducer
             };
 
-            if (listener == null)
-            {
-                listener = new WebExtensionListener(Configuration.UrlSuffix);
-            }
-
-            listener.StartListening();
-            foreach (var producer in producers)
-            {
-                listener.Subscribe(producer, producer.HandledEventLabel);
-            }
-
             if (isEnabled)
             {
+                if (listener == null)
+                {
+                    listener = new WebExtensionListener(Configuration.UrlSuffix);
+                }
+
+                foreach (var producer in producers)
+                {
+                    listener.Subscribe(producer, producer.HandledEventLabel);
+                }
+                listener.StartListening();
                 producers.ForEach(producer => producer.Open());
             }
             else

--- a/application/Modules/WebBrowser/WebExtensionListener.cs
+++ b/application/Modules/WebBrowser/WebExtensionListener.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using MORR.Shared.Utility;
@@ -21,7 +23,7 @@ namespace MORR.Modules.WebBrowser
         private const int
             ERROR_OPERATION_ABORTED = 995; //errorcode thrown by the async function when listener is stopped
 
-        private readonly HttpListener listener;
+        private const int ERROR_ALREADY_EXISTS = 183;
 
         //deliberately don't use IList, as RemoveAll function is used later
         private readonly Dictionary<EventLabel, List<IWebBrowserEventObserver>> observers;
@@ -30,6 +32,10 @@ namespace MORR.Modules.WebBrowser
         //depends on the way the asynchronous BeginGetContext is handled internally
         private readonly ConcurrentQueue<HttpListenerResponse> startQueue;
         private readonly ConcurrentQueue<HttpListenerResponse> stopQueue;
+
+        private HttpListener? listener;
+
+        private readonly Uri listenerPrefix;
         private bool recordingActive;
 
         /// <summary>
@@ -47,10 +53,7 @@ namespace MORR.Modules.WebBrowser
         /// <exception cref="UriFormatException">If the urlSuffix is invalid.</exception>
         public WebExtensionListener(string urlSuffix)
         {
-            listener = new HttpListener();
-            //this might throw the HttpListenerException
-            listener.Prefixes.Add(new Uri(URLPREFIX + urlSuffix)
-                                      .ToString()); //the short conversion to Uri is just to check URL validity
+            listenerPrefix = new Uri(URLPREFIX + urlSuffix);
             startQueue = new ConcurrentQueue<HttpListenerResponse>();
             stopQueue = new ConcurrentQueue<HttpListenerResponse>();
             observers = new Dictionary<EventLabel, List<IWebBrowserEventObserver>>();
@@ -67,10 +70,34 @@ namespace MORR.Modules.WebBrowser
         /// </summary>
         public void StartListening()
         {
-            if (!listener.IsListening)
+            if (listener == null || !listener.IsListening)
             {
-                listener.Start();
-                listener.BeginGetContext(RetrieveRequest, null);
+                if (listener == null)
+                {
+                    listener = new HttpListener();
+                    listener.Prefixes.Add(listenerPrefix.ToString());
+                }
+
+                try
+                {
+                    listener.Start();
+                    listener.BeginGetContext(RetrieveRequest, null);
+                }
+                catch (HttpListenerException ex)
+                {
+                    if (ex.ErrorCode == ERROR_ALREADY_EXISTS)
+                    {
+                        StopForeignInstance();
+                        listener = new HttpListener();
+                        listener.Prefixes.Add(listenerPrefix.ToString());
+                        listener.Start();
+                        listener.BeginGetContext(RetrieveRequest, null);
+                    }
+                    else
+                    {
+                        throw ex;
+                    }
+                }
             }
         }
 
@@ -79,9 +106,14 @@ namespace MORR.Modules.WebBrowser
         /// </summary>
         public void StopListening()
         {
+            StopListening(null);
+        }
+
+        //Stop listening, but respond to context just before stopping
+        private void StopListening(HttpListenerContext? context)
+        {
             if (listener.IsListening)
             {
-                listener.Stop();
                 //inform all the connected applications about the listener having stopped
                 foreach (var response in startQueue)
                 {
@@ -92,6 +124,16 @@ namespace MORR.Modules.WebBrowser
                 {
                     AnswerRequest(response, new WebBrowserResponse("Quit"));
                 }
+
+                if (context != null)
+                {
+                    AnswerRequest(context.Response, new WebBrowserResponse(ResponseStrings.POSITIVERESPONSE));
+                }
+
+                listener.Stop();
+                startQueue.Clear();
+                stopQueue.Clear();
+                listener = null;
             }
         }
 
@@ -134,7 +176,8 @@ namespace MORR.Modules.WebBrowser
             CONFIG,
             START,
             SENDDATA,
-            WAITSTOP
+            WAITSTOP,
+            STOPLISTENING
         }
 
         #endregion
@@ -144,10 +187,11 @@ namespace MORR.Modules.WebBrowser
         //the possible responses to send
         private sealed class ResponseStrings
         {
-            public static readonly string POSITIVERESPONSE = "Ok";
-            public static readonly string NEGATIVERESPONSE = "Invalid Request";
-            public static readonly string STARTRESPONSE = "Start";
-            public static readonly string STOPRESPONSE = "Stop";
+            public const string POSITIVERESPONSE = "Ok";
+            public const string NEGATIVERESPONSE = "Invalid Request";
+            public const string STARTRESPONSE = "Start";
+            public const string STOPRESPONSE = "Stop";
+            public const string REQUESTDENIED = "Denied";
         }
 
         private static readonly string URLPREFIX = "http://localhost:";
@@ -161,8 +205,6 @@ namespace MORR.Modules.WebBrowser
         /// </summary>
         private void Start()
         {
-            //start listening in case the listener is not yet doing so
-            StartListening();
             foreach (var response in startQueue)
             {
                 AnswerRequest(response, new WebBrowserResponse(ResponseStrings.STARTRESPONSE));
@@ -187,10 +229,13 @@ namespace MORR.Modules.WebBrowser
         //retrieve and parse another incoming request
         private void RetrieveRequest(IAsyncResult result)
         {
-            HttpListenerContext context;
+            HttpListenerContext? context = null;
             try
             {
-                context = listener.EndGetContext(result);
+                if (listener != null)
+                {
+                    context = listener.EndGetContext(result);
+                }
             }
             catch (HttpListenerException ex)
             {
@@ -201,6 +246,11 @@ namespace MORR.Modules.WebBrowser
                 }
 
                 throw ex;
+            }
+
+            if (context == null)
+            {
+                return;
             }
 
             var request = context.Request;
@@ -294,6 +344,19 @@ namespace MORR.Modules.WebBrowser
                         }
 
                         break;
+                    case WebBrowserRequestType.STOPLISTENING:
+                        if (!recordingActive)
+                        {
+                            //stop listening to allow other instance to record on the specified port
+                            StopListening(context);
+                        }
+                        else
+                        {
+                            //do not terminate if a recording is currently active
+                            AnswerRequest(context.Response, new WebBrowserResponse(ResponseStrings.REQUESTDENIED));
+                        }
+
+                        break;
                     default:
                         //theoretically unreachable, as Enum.TryParse should have failed in this case
                         AnswerInvalid(context.Response);
@@ -319,7 +382,7 @@ namespace MORR.Modules.WebBrowser
             output.Close();
         }
 
-        //decode an URL-encoded string to UTF8 (i think)
+        //decode an URL-encoded string to UTF8
         private static string DecodeUrlString(string url)
         {
             string newUrl;
@@ -347,6 +410,57 @@ namespace MORR.Modules.WebBrowser
 
             NotifyAll(parsed, label);
             return true;
+        }
+
+        //send stoplistening-request to the specified address, attempting to shut down another instance of webextension listener.
+        private void StopForeignInstance()
+        {
+            using (var client = new HttpClient())
+            {
+                client.BaseAddress = listenerPrefix;
+                client.DefaultRequestHeaders
+                      .Accept
+                      .Add(new MediaTypeWithQualityHeaderValue("application/json")); //ACCEPT header
+                var response = SendHTTPMessage(new { Request = "STOPLISTENING" }, client);
+                if (!response.TryGetProperty("application", out var applicationId) ||
+                    !applicationId.ValueEquals("MORR"))
+                {
+                    throw new InvalidDataException("HTTP response did not contain a valid 'application' identifier.");
+                }
+
+                if (!response.TryGetProperty("response", out var answer))
+                {
+                    throw new InvalidDataException("HTTP response did not contain a 'response' field.");
+                }
+
+                if (answer.ValueEquals(ResponseStrings.POSITIVERESPONSE)) { }
+                else if (answer.ValueEquals(ResponseStrings.REQUESTDENIED))
+                {
+                    throw new InvalidOperationException(
+                        "Another instance of MORR is actively recording on this system.");
+                }
+                else
+                {
+                    throw new InvalidDataException("Received unexpected answer: " + answer);
+                }
+            }
+        }
+
+        private JsonElement SendHTTPMessage(object data, HttpClient client)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, "relativeAddress");
+            request.Content = new StringContent(JsonSerializer.Serialize(data),
+                                                Encoding.UTF8,
+                                                "application/json"); //CONTENT-TYPE header
+
+            var response = client.PostAsync(listenerPrefix, request.Content).Result;
+            var result = response.Content.ReadAsStringAsync().Result;
+            return GetJsonFromString(result);
+        }
+
+        private static JsonElement GetJsonFromString(string data)
+        {
+            return JsonDocument.Parse(data).RootElement;
         }
 
         #endregion

--- a/application/Modules/WebBrowser/WebExtensionListener.cs
+++ b/application/Modules/WebBrowser/WebExtensionListener.cs
@@ -112,6 +112,8 @@ namespace MORR.Modules.WebBrowser
         //Stop listening, but respond to context just before stopping
         private void StopListening(HttpListenerContext? context)
         {
+            if (listener == null)
+                return;
             if (listener.IsListening)
             {
                 //inform all the connected applications about the listener having stopped

--- a/application/Modules/WebBrowserTest/WebBrowserModuleTest.cs
+++ b/application/Modules/WebBrowserTest/WebBrowserModuleTest.cs
@@ -304,6 +304,35 @@ namespace WebBrowserTest
             await result;
         }
 
+        [TestMethod]
+        public async Task StopListeningSuccess()
+        {
+            // Preconditions
+            webBrowserModule.Initialize(true);
+
+            /* THEN */
+            var result = await SendHTTPMessage(new { Request = "STOPLISTENING" });
+
+            /* THEN */
+            Assert.AreEqual(StringConstants.okString, result.GetProperty("response").GetString());
+            Assert.AreEqual(StringConstants.appIdentifier, result.GetProperty("application").GetString());
+        }
+
+        [TestMethod]
+        public async Task StopListeningDenied()
+        {
+            // Preconditions
+            webBrowserModule.Initialize(true);
+            webBrowserModule.IsActive = true;
+            /* THEN */
+            var result = await SendHTTPMessage(new { Request = "STOPLISTENING" });
+
+            /* THEN */
+            Assert.AreEqual(StringConstants.requestDenied, result.GetProperty("response").GetString());
+            Assert.AreEqual(StringConstants.appIdentifier, result.GetProperty("application").GetString());
+            Assert.IsTrue((webBrowserModule.IsActive));
+        }
+
         private async Task ChangeModuleActiveState(bool active)
         {
             await Task.Run(() =>
@@ -351,6 +380,7 @@ namespace WebBrowserTest
             public const string startString = "Start";
             public const string stopString = "Stop";
             public const string invalidString = "Invalid Request";
+            public const string requestDenied = "Denied";
         }
 
         private class TestWebBrowserModuleConfiguration : WebBrowserModuleConfiguration


### PR DESCRIPTION
This PR introduces following fixes/features to WebbrowserModule:

- The `StopListening()` function of `WebExtensionListener` no longer throws an exception when an instance of the BrowserExtension has a request queued
- The Listener no longer becomes active when the module is not activated in the configuration (bug was introduced with the changes to the Initialization logic in #109)
- When a listener attempts to start on an occupied port, it will send a STOPLISTENING request to the port, expecting another instance of MORR to occupy it. If the other instance is not actively recording, it will stop listening and thus release the port, effectively allowing multiple instances of MORR to run on the same system, even if they use the same port. If the other instance refuses to free the port (because it is recording, or another service entirely), MORR will still crash with an exception, but it is more descriptive now.
- Fixed `WebExtensionListener` not always being reusable (calling `StartListening` after `StopListening` was likely to throw) by always creating a new instance of `HttpListener` when starting.

Closes #66 
Closes #126