### PR TITLE
Enable default configuration paths

### DIFF
--- a/application/Core/UI/App.xaml.cs
+++ b/application/Core/UI/App.xaml.cs
@@ -24,7 +24,7 @@ namespace MORR.Core.UI
 
             HasLanguageCommandLineArgument = Environment.GetCommandLineArgs().Any(IsLanguageCommandLineArgument);
 
-            if (HasLanguageCommandLineArgument)
+            if (!HasLanguageCommandLineArgument)
             {
                 Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
                 Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("de-DE");

--- a/application/Core/UI/App.xaml.cs
+++ b/application/Core/UI/App.xaml.cs
@@ -11,9 +11,9 @@ namespace MORR.Core.UI
     /// </summary>
     public partial class App : Application
     {
-        public static bool HasLanguageCommandLineArgument { get; private set; }
+        internal static bool HasLanguageCommandLineArgument { get; private set; }
 
-        public static bool IsLanguageCommandLineArgument(string argument)
+        internal static bool IsLanguageCommandLineArgument(string argument)
         {
             return string.CompareOrdinal(argument, "no-force-german-ui") == 0;
         }

--- a/application/Core/UI/App.xaml.cs
+++ b/application/Core/UI/App.xaml.cs
@@ -11,14 +11,20 @@ namespace MORR.Core.UI
     /// </summary>
     public partial class App : Application
     {
+        public static bool HasLanguageCommandLineArgument { get; private set; }
+
+        public static bool IsLanguageCommandLineArgument(string argument)
+        {
+            return string.CompareOrdinal(argument, "no-force-german-ui") == 0;
+        }
+
         public App()
         {
             // Set culture before WPF components get initialized so they use the correct language
 
-            var forceGerman = Environment.GetCommandLineArgs()
-                                         .All(x => string.CompareOrdinal(x, "no-force-german-ui") != 0);
+            HasLanguageCommandLineArgument = Environment.GetCommandLineArgs().Any(IsLanguageCommandLineArgument);
 
-            if (forceGerman)
+            if (HasLanguageCommandLineArgument)
             {
                 Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
                 Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("de-DE");

--- a/application/Core/UI/Properties/Resources.Designer.cs
+++ b/application/Core/UI/Properties/Resources.Designer.cs
@@ -71,7 +71,7 @@ namespace MORR.Core.UI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No configuration has been specified. Please specify a configuration file as the command line argument..
+        ///   Looks up a localized string similar to No configuration has been specified. Please specify a configuration file as the command line argument or ensure a configuration file named &quot;config.morr&quot; exists relative to the executable..
         /// </summary>
         public static string Error_No_Configuration_Specified {
             get {

--- a/application/Core/UI/Properties/Resources.de-DE.resx
+++ b/application/Core/UI/Properties/Resources.de-DE.resx
@@ -122,7 +122,7 @@
 Bitte überprüfen Sie die Konfiguration oder kontaktieren Sie einen Administrator.</value>
   </data>
   <data name="Error_No_Configuration_Specified" xml:space="preserve">
-    <value>Keine Konfigurationsdatei spezifiziert. Bitte spezifizieren Sie eine Konfigurationsdatei als Kommandozeilenparameter.</value>
+    <value>Keine Konfigurationsdatei spezifiziert. Bitte spezifizieren Sie eine Konfigurationsdatei als Kommandozeilenparameter oder stellen Sie sicher, dass eine Datei mit dem Namen "config.morr" relativ zur Applikation existiert.</value>
   </data>
   <data name="Error_No_Recordings_Directory" xml:space="preserve">
     <value>Das Aufnahmeverzeichnis konnte nicht gefunden werden.

--- a/application/Core/UI/Properties/Resources.resx
+++ b/application/Core/UI/Properties/Resources.resx
@@ -122,7 +122,7 @@
 Please check the configuration file or contact an administrator.</value>
   </data>
   <data name="Error_No_Configuration_Specified" xml:space="preserve">
-    <value>No configuration has been specified. Please specify a configuration file as the command line argument.</value>
+    <value>No configuration has been specified. Please specify a configuration file as the command line argument or ensure a configuration file named "config.morr" exists relative to the executable.</value>
   </data>
   <data name="Error_No_Recordings_Directory" xml:space="preserve">
     <value>The recordings folder could not be found.

--- a/application/Core/UI/Properties/launchSettings.json
+++ b/application/Core/UI/Properties/launchSettings.json
@@ -4,6 +4,9 @@
       "commandName": "Project",
       "commandLineArgs": "config.morr",
       "workingDirectory": "$(SolutionDir)\\BuildEnvironment"
+    },
+    "DefaultConfig": {
+      "commandName": "Project"
     }
   }
 }

--- a/application/Core/UI/ViewModels/ApplicationViewModel.cs
+++ b/application/Core/UI/ViewModels/ApplicationViewModel.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Interop;
@@ -28,7 +29,7 @@ namespace MORR.Core.UI.ViewModels
         {
             try
             {
-                var configurationPath = GetConfigurationPathFromCommandLine();
+                var configurationPath = GetConfigurationPath();
                 sessionManager = new SessionManager(configurationPath);
             }
             catch (Exception)
@@ -120,18 +121,48 @@ namespace MORR.Core.UI.ViewModels
 
         #region Utility
 
-        private static FilePath GetConfigurationPathFromCommandLine()
+        private static FilePath GetConfigurationPath()
         {
-            var commandLineArguments = Environment.GetCommandLineArgs();
+            if (TryGetConfigurationPathFromCommandLine(out var path))
+            {
+                return path;
+            }
 
-            if (commandLineArguments.Length < 2)
+            var defaultConfigurationBasePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+            if (defaultConfigurationBasePath == null)
             {
                 ExitWithError(Properties.Resources.Error_No_Configuration_Specified);
             }
 
+            var defaultConfigurationPath = Path.Combine(defaultConfigurationBasePath, "config.morr");
+
+            return new FilePath(Path.GetFullPath(defaultConfigurationPath));
+        }
+
+        private static bool TryGetConfigurationPathFromCommandLine([NotNullWhen(true)] out FilePath? path)
+        {
+            var commandLineArguments = Environment.GetCommandLineArgs();
+
+            if (commandLineArguments.Length < 2 || (App.HasLanguageCommandLineArgument && commandLineArguments.Length < 3))
+            {
+                // If no command line argument has been specified or only one has been specified
+                // and that argument is used to set the language, then the configuration path must be set to the default value
+                path = null;
+                return false;
+            }
+
             // The first argument is the current assembly, the second argument is the first actual command line argument
             var configurationPathArgument = commandLineArguments.ElementAt(1);
-            return new FilePath(Path.GetFullPath(configurationPathArgument));
+
+            if (App.IsLanguageCommandLineArgument(configurationPathArgument))
+            {
+                // If the first specified argument is used to set the language, then the path must be the second argument
+                configurationPathArgument = commandLineArguments.ElementAt(2);
+            }
+
+            path = new FilePath(Path.GetFullPath(configurationPathArgument));
+            return true;
         }
 
         [DoesNotReturn]


### PR DESCRIPTION
This PR enables loading the configuration from a file named "config.morr" relative to the executeable without specifying a command line argument.
I have added a new profile ("DefaultConfig") which launches the application without any command line arguments for testing purposes.

Closes #124 