### PR TITLE
Cliboard module not recording certain events

### DIFF
--- a/application/Modules/Clipboard/ClipboardModule.cs
+++ b/application/Modules/Clipboard/ClipboardModule.cs
@@ -68,9 +68,8 @@ namespace MORR.Modules.Clipboard
 
         private void StartCapture()
         {
-            INativeClipboard nativeCb = new NativeClipboard();
             ClipboardCutEventProducer?.StartCapture();
-            ClipboardPasteEventProducer?.StartCapture(nativeCb);
+            ClipboardPasteEventProducer?.StartCapture();
             ClipboardCopyEventProducer?.StartCapture();
         }
 

--- a/application/Modules/Clipboard/Producers/ClipboardCopyEventProducer.cs
+++ b/application/Modules/Clipboard/Producers/ClipboardCopyEventProducer.cs
@@ -11,9 +11,7 @@ namespace MORR.Modules.Clipboard.Producers
     /// </summary>
     public class ClipboardCopyEventProducer : DefaultEventQueue<ClipboardCopyEvent>
     {
-        private const int wparamnull = 0;
-
-        private const int wparamcopy = 18;
+        private const int wparamcut = 14;
 
         private static readonly ClipboardWindowMessageSink
             clipboardWindowMessageSink = new ClipboardWindowMessageSink();
@@ -39,12 +37,12 @@ namespace MORR.Modules.Clipboard.Producers
                 return;
             }
 
-            if (wParam.ToInt64() == wparamnull || wParam.ToInt64() == wparamcopy)
+            if (wParam.ToInt64() != wparamcut)
             {
                 var clipboardCopyEvent = new ClipboardCopyEvent
                     { ClipboardText = text, IssuingModule = ClipboardModule.Identifier };
                 Enqueue(clipboardCopyEvent);
-            } 
+            }
         }
 
         #endregion

--- a/application/Modules/Clipboard/Producers/ClipboardPasteEventProducer.cs
+++ b/application/Modules/Clipboard/Producers/ClipboardPasteEventProducer.cs
@@ -11,11 +11,10 @@ namespace MORR.Modules.Clipboard.Producers
     /// </summary>
     public class ClipboardPasteEventProducer : DefaultEventQueue<ClipboardPasteEvent>
     {
-        private static INativeClipboard nativeClipboard;
+        private static readonly INativeClipboard nativeClipboard = new NativeClipboard();
 
-        public void StartCapture(INativeClipboard nativeCb)
+        public void StartCapture()
         {
-            nativeClipboard = nativeCb;
             GlobalHook.IsActive = true;
             GlobalHook.AddListener(GlobalHookCallBack, GlobalHook.MessageType.WM_PASTE);
         }


### PR DESCRIPTION
Closes #158 

ClipboardCopyProducer now accepts all values of wParam except for wParam for cut. 
ClipboardCutProducer uses both WM_CLIPBOARDUPDATE and WM_CUT messages.

Not all apps send WM_CUT message (like WM_PASTE) and wParams are often equal for cut and copy, therefore ClipboardCutEvent is expected to be recognized as ClipboardCopyEvent in most cases.

Some apps also send ClipboardEvents more than one time for one copying/cutting.

