### PR TITLE
Disable FreeConsumer test as long #173 is resolved

### DIFF
--- a/application/Common/SharedTest/Events/Queue/Strategy/MultiConsumer/MultiConsumerChannelStrategyTest.cs
+++ b/application/Common/SharedTest/Events/Queue/Strategy/MultiConsumer/MultiConsumerChannelStrategyTest.cs
@@ -42,6 +42,10 @@ namespace SharedTest.Events.Queue.Strategy.MultiConsumer
             Assert.IsTrue(invalidConsumerFailed.WaitOne(maxWaitTime), "InvalidConsumer should fail.");
         }
 
+        /// <summary>
+        /// This test seems to fail only on the CI. An Issue (#173) has been created.
+        /// </summary>
+        [Ignore]
         [TestMethod]
         public void TestMultiConsumer_FreeConsumer()
         {


### PR DESCRIPTION
Disables the FreeConsumer test for MultiConsumerChannelStrategies until it is addressed as this test only fails on the CI.