### PR TITLE
Improve EnqueueAsync method on heavy load

### DIFF
--- a/application/Common/Shared/Events/Queue/Strategy/MultiConsumer/MultiConsumerChannelStrategy.cs
+++ b/application/Common/Shared/Events/Queue/Strategy/MultiConsumer/MultiConsumerChannelStrategy.cs
@@ -98,11 +98,11 @@ namespace MORR.Shared.Events.Queue.Strategy.MultiConsumer
             IsClosed = true;
             subscriptionMutex.ReleaseMutex();
 
-            receivingChannel?.Writer?.Complete();
+            receivingChannel?.Writer.TryComplete();
 
             foreach (var channel in offeringChannels)
             {
-                channel?.Writer?.Complete();
+                channel?.Writer.TryComplete();
             }
         }
 

--- a/application/Common/Shared/Events/Queue/Strategy/SingleConsumer/SingleConsumerChannelStrategy.cs
+++ b/application/Common/Shared/Events/Queue/Strategy/SingleConsumer/SingleConsumerChannelStrategy.cs
@@ -84,7 +84,7 @@ namespace MORR.Shared.Events.Queue.Strategy.SingleConsumer
             IsClosed = true;
             subscriptionMutex.ReleaseMutex();
 
-            eventChannel?.Writer.Complete();
+            eventChannel?.Writer.TryComplete();
             FreeReading();
         }
 


### PR DESCRIPTION
This PR improves the EnqueueAsync methods of both ChannelStrategies.

Previously it was possible that due to a heavy load, queueing of an event may be asynchronously delayed.

This also causes some tests to fail in my experience.

However if the delayed task is still not finished the task may fail with a ChannelClosedException which results in a crash of the system. The new approach adds exception handling for exactly this case.

Finally this PR also uses TryComplete() instead of Complete(), as this method does not fail if a currently completed channel is closed again.