### PR TITLE
Simplify installation / distribute dependencies

### DIFF
--- a/application/BuildEnvironment/config.morr
+++ b/application/BuildEnvironment/config.morr
@@ -7,7 +7,8 @@
       "MORR.Modules.WindowManagement.WindowManagementModule",
       "MORR.Modules.Keyboard.KeyboardModule",
       "MORR.Modules.Mouse.MouseModule",
-      "MORR.Modules.Clipboard.ClipboardModule"
+      "MORR.Modules.Clipboard.ClipboardModule",
+      "MORR.Modules.WebBrowser.WebBrowserModule"
     ]
   },
   "MORR.Core.Session.SessionConfiguration": {

--- a/application/Common/HookLibrary/HookLibrary.vcxproj
+++ b/application/Common/HookLibrary/HookLibrary.vcxproj
@@ -135,6 +135,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>
       </PrecompiledHeaderFile>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -155,6 +156,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>
       </PrecompiledHeaderFile>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/application/Common/SharedTest/SharedTest.csproj
+++ b/application/Common/SharedTest/SharedTest.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
     <IsPackable>false</IsPackable>
+	<IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/application/Common/Win32HookHelper/Win32HookHelper.vcxproj
+++ b/application/Common/Win32HookHelper/Win32HookHelper.vcxproj
@@ -119,6 +119,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -137,6 +138,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/application/Core/CLITest/CLITest.csproj
+++ b/application/Core/CLITest/CLITest.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
     <IsPackable>false</IsPackable>
+	<IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/application/Core/MORRTest/MORRTest.csproj
+++ b/application/Core/MORRTest/MORRTest.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
     <IsPackable>false</IsPackable>
+	<IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/application/Core/UITest/UITest.csproj
+++ b/application/Core/UITest/UITest.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
     <IsPackable>false</IsPackable>
+	<IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/application/Modules/ClipboardTest/ClipboardTest.csproj
+++ b/application/Modules/ClipboardTest/ClipboardTest.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
     <IsPackable>false</IsPackable>
+	<IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/application/Modules/KeyboardTest/KeyboardTest.csproj
+++ b/application/Modules/KeyboardTest/KeyboardTest.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
     <IsPackable>false</IsPackable>
+	<IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/application/Modules/MouseTest/MouseTest.csproj
+++ b/application/Modules/MouseTest/MouseTest.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
     <IsPackable>false</IsPackable>
+	<IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/application/Modules/WebBrowserTest/WebBrowserTest.csproj
+++ b/application/Modules/WebBrowserTest/WebBrowserTest.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
     <IsPackable>false</IsPackable>
+	<IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/application/Modules/WindowManagementTest/WindowManagementTest.csproj
+++ b/application/Modules/WindowManagementTest/WindowManagementTest.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
     <IsPackable>false</IsPackable>
+	<IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/application/publish.bat
+++ b/application/publish.bat
@@ -1,22 +1,13 @@
 @echo off
-set targetframework=netcoreapp3.1
-set outdir=publishing
-set moduleoutdir=publishing\Modules
-set noselfcontained=( ^
-Core\CLI\CLI.csproj ^
-Common\Shared\Shared.csproj)
-set coreprojects=( ^
-Core\MORR\MORR.csproj ^
-Core\UI\UI.csproj)
-set noselfcontainedmodules=( ^
-Modules\Mouse\Mouse.csproj ^
-Modules\WindowManagement\WindowManagement.csproj)
-set modules=( ^
-Modules\Clipboard\Clipboard.csproj ^
-Modules\Keyboard\Keyboard.csproj ^
-Modules\Webbrowser\WebBrowser.csproj)
-for %%i in %noselfcontained% do dotnet publish -o %outdir% -f %targetframework% -c release %%i
-for %%i in %coreprojects% do dotnet publish -o %outdir% -c release -r win10-x64 -f %targetframework% --self-contained true %%i
-for %%i in %modules% do dotnet publish -o %moduleoutdir% -c release -r win10-x64 -f %targetframework% --self-contained true %%i
-for %%i in %noselfcontainedmodules% do dotnet publish -o %moduleoutdir% -c release -f %targetframework% %%i
+set outdir=publish
+set "ModuleExt=MORR-Module.dll"
+dotnet clean
+dotnet publish -c release --no-dependencies -o %outdir% MORR.sln
+dotnet clean
+dotnet publish -c release --no-dependencies -o %outdir% -r win-x64 --self-contained true MORR.sln
+md %outdir%\Modules
+move %outdir%\*%ModuleExt% %outdir%\Modules\
+copy build\Release\x64\HookLibrary*.dll %outdir%\
+copy build\Release\x64\Win32HookHelper.exe %outdir%\
+copy BuildEnvironment\config.morr %outdir%\
 set /p asd="Hit enter to continue"

--- a/application/publish.bat
+++ b/application/publish.bat
@@ -1,0 +1,22 @@
+@echo off
+set targetframework=netcoreapp3.1
+set outdir=publishing
+set moduleoutdir=publishing\Modules
+set noselfcontained=( ^
+Core\CLI\CLI.csproj ^
+Common\Shared\Shared.csproj)
+set coreprojects=( ^
+Core\MORR\MORR.csproj ^
+Core\UI\UI.csproj)
+set noselfcontainedmodules=( ^
+Modules\Mouse\Mouse.csproj ^
+Modules\WindowManagement\WindowManagement.csproj)
+set modules=( ^
+Modules\Clipboard\Clipboard.csproj ^
+Modules\Keyboard\Keyboard.csproj ^
+Modules\Webbrowser\WebBrowser.csproj)
+for %%i in %noselfcontained% do dotnet publish -o %outdir% -f %targetframework% -c release %%i
+for %%i in %coreprojects% do dotnet publish -o %outdir% -c release -r win10-x64 -f %targetframework% --self-contained true %%i
+for %%i in %modules% do dotnet publish -o %moduleoutdir% -c release -r win10-x64 -f %targetframework% --self-contained true %%i
+for %%i in %noselfcontainedmodules% do dotnet publish -o %moduleoutdir% -c release -f %targetframework% %%i
+set /p asd="Hit enter to continue"


### PR DESCRIPTION
This PR adds a publish-script which will (hopefully) compile MORR and add all dependencies except the .NET Core Runtime itself.

The script expects to be run in the **application** directory where it is located. It also expects a release build of at least the HookLibrary and the Win32HookHelper being compiled as it just copies the respective files from the release folder.

Static linking of the VC++ Runtime in the C++ projects might need to be reverted as Windows Defender may now rate these files to be dangerous.

Closes #199 